### PR TITLE
vehicleshop overhaul

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -295,7 +295,10 @@ function Init()
             rotation = 0,
             debug = false,
             onEnter = enteringFinancingZone,
-            inside = insideFinancingZone
+            inside = insideFinancingZone,
+            onExit = function()
+                lib.hideTextUI()
+            end
         })
     end)
 

--- a/client.lua
+++ b/client.lua
@@ -14,17 +14,6 @@ lib.registerContext({
     }
 })
 
-lib.registerContext({ 
-    id = 'rettestdrive_header_menu',
-    title = Lang:t('menus.returnTestDrive_header'),
-    options = {
-        {
-            title = Lang:t('menus.finance_txt'),
-            event = 'qb-vehicleshop:client:TestDriveReturn'
-        }
-    }
-})
-
 local Initialized = false
 local testDriveVeh, inTestDrive = 0, false
 local ClosestVehicle = 1

--- a/client.lua
+++ b/client.lua
@@ -1,4 +1,3 @@
--- Variables
 local QBCore = exports['qb-core']:GetCoreObject()
 local PlayerData = QBCore.Functions.GetPlayerData()
 local testDriveZone = nil
@@ -712,7 +711,6 @@ RegisterNetEvent('qb-vehicleshop:client:openIdMenu', function(data)
     end
 end)
 
--- Threads
 CreateThread(function()
     for k, v in pairs(Config.Shops) do
         if v.showBlip then

--- a/client.lua
+++ b/client.lua
@@ -186,7 +186,7 @@ local function startTestDriveTimer(testDriveTime, shop)
                     TriggerServerEvent('qb-vehicleshop:server:deleteVehicle', testDriveVeh)
                     testDriveVeh = 0
                     inTestDrive = false
-                    SetEntityCoords(cache.ped, Config.Shops[shop]['TestDriveReturnLocation'])
+                    SetEntityCoords(cache.ped, Config.Shops[shop].TestDriveReturnLocation)
                     lib.notify({
                         title = Lang:t('general.testdrive_complete'),
                         type = 'success'
@@ -200,21 +200,21 @@ local function startTestDriveTimer(testDriveTime, shop)
 end
 
 local function enteringVehicleSellZone()
-    if PlayerData and PlayerData.job and (PlayerData.job.name == Config.Shops[insideShop]['Job'] or Config.Shops[insideShop]['Job'] == 'none') then
-        lib.showTextUI(Lang:t('menus.keypress_vehicleViewMenu'))
+    local job = Config.Shops[insideShop].Job
+    if not PlayerData or not PlayerData.job or (PlayerData.job.name ~= job and job ~= 'none') then
+        return
     end
+
+    lib.showTextUI(Lang:t('menus.keypress_vehicleViewMenu'))
 end
 
 local function insideVehicleSellZone()
-    if IsControlJustPressed(0, 38) then
-        if PlayerData and PlayerData.job and (PlayerData.job.name == Config.Shops[insideShop]['Job'] or Config.Shops[insideShop]['Job'] == 'none') then
-            openVehicleSellMenu()
-        end
+    local job = Config.Shops[insideShop].Job
+    if not IsControlJustPressed(0, 38) or not PlayerData or not PlayerData.job or (PlayerData.job.name ~= job and job ~= 'none') then
+        return
     end
-end
 
-local function exitingVehicleSellZone()
-    lib.hideTextUI()
+    openVehicleSellMenu()
 end
 
 local function createVehZones(shopName, entity)
@@ -223,26 +223,31 @@ local function createVehZones(shopName, entity)
             local vehData = Config.Shops[shopName]['ShowroomVehicles'][i]
             zones[#zones + 1] = lib.zones.box({
                 coords = vec3(vehData.coords.x, vehData.coords.y, vehData.coords.z),
-                size = Config.Shops[shopName]['Zone']['size'],
+                size = Config.Shops[shopName].Zone.size,
                 rotation = vehData.coords.w,
-                debug = Config.Shops[shopName]['Zone']['debug'],
+                debug = Config.Shops[shopName].Zone.debug,
                 onEnter = enteringVehicleSellZone,
                 inside = insideVehicleSellZone,
-                onExit = exitingVehicleSellZone
+                onExit = function()
+                    lib.hideTextUI()
+                end
             })
         end
     else
-        exports.ox_target:addLocalEntity(entity, { {
-            name = 'vehicleshop:showVehicleOptions',
-            icon = "fas fa-car",
-            label = Lang:t('general.vehinteraction'),
-            onSelect = function()
-                openVehicleSellMenu()
-            end
-        } })
+        exports.ox_target:addLocalEntity(entity, {
+            {
+                name = 'vehicleshop:showVehicleOptions',
+                icon = "fas fa-car",
+                label = Lang:t('general.vehinteraction'),
+                onSelect = function()
+                    openVehicleSellMenu()
+                end
+            }
+        })
     end
 end
 
+---@param self object
 local function enterShop(self)
     insideShop = self.name
     setClosestShowroomVehicle()
@@ -258,7 +263,7 @@ function createShop(shopShape, name)
         name = name,
         points = shopShape,
         thickness = 5,
-        debug = Config.Shops[name]['Zone']['debug'],
+        debug = Config.Shops[name].Zone.debug,
         onEnter = enterShop,
         onExit = exitShop
     })
@@ -272,10 +277,6 @@ local function insideFinancingZone()
     if IsControlJustPressed(0, 38) then
         lib.showContext('fin_header_menu')
     end
-end
-
-local function exitingFinancingZone()
-    lib.hideTextUI()
 end
 
 function Init()
@@ -294,8 +295,7 @@ function Init()
             rotation = 0,
             debug = false,
             onEnter = enteringFinancingZone,
-            inside = insideFinancingZone,
-            onExit = exitingFinancingZone
+            inside = insideFinancingZone
         })
     end)
 

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,5 @@
 Config = {}
-Config.UsingTarget = false
+Config.UsingTarget = GetConvar('UseTarget', 'false') == 'true'
 Config.Commission = 0.10 -- Percent that goes to sales person from a full car sale 10%
 Config.FinanceCommission = 0.05 -- Percent that goes to sales person from a finance sale 5%
 Config.FinanceZone = vector3(-29.53, -1103.67, 26.42)-- Where the finance menu is located

--- a/config.lua
+++ b/config.lua
@@ -13,18 +13,17 @@ Config.Shops = {
         ['Type'] = 'free-use', -- no player interaction is required to purchase a car
         ['Zone'] = {
             ['Shape'] = {--polygon that surrounds the shop
-                vector2(-56.727394104004, -1086.2325439453),
-                vector2(-60.612808227539, -1096.7795410156),
-                vector2(-58.26834487915, -1100.572265625),
-                vector2(-35.927803039551, -1109.0034179688),
-                vector2(-34.427627563477, -1108.5111083984),
-                vector2(-32.02657699585, -1101.5877685547),
-                vector2(-33.342102050781, -1101.0377197266),
-                vector2(-31.292987823486, -1095.3717041016)
+                vector3(-56.727394104004, -1086.2325439453, 26.0),
+                vector3(-60.612808227539, -1096.7795410156, 26.0),
+                vector3(-58.26834487915, -1100.572265625, 26.0),
+                vector3(-35.927803039551, -1109.0034179688, 26.0),
+                vector3(-34.427627563477, -1108.5111083984, 26.0),
+                vector3(-32.02657699585, -1101.5877685547, 26.0),
+                vector3(-33.342102050781, -1101.0377197266, 26.0),
+                vector3(-31.292987823486, -1095.3717041016, 26.0)
             },
-            ['minZ'] = 25.0, -- min height of the shop zone
-            ['maxZ'] = 28.0, -- max height of the shop zone
-            ['size'] = 2.75 -- size of the vehicles zones
+            ['size'] = vector3(3, 3, 4), -- size of the vehicles zones (x, y, z)
+            ['debug'] = false
         },
         ['Job'] = 'none', -- Name of job or none
         ['ShopLabel'] = 'Premium Deluxe Motorsport', -- Blip name
@@ -44,6 +43,7 @@ Config.Shops = {
             ['cycles'] = 'Bicycles'
         },
         ['TestDriveTimeLimit'] = 0.5, -- Time in minutes until the vehicle gets deleted
+        ['TestDriveReturnLocation'] = vector4(-39.04, -1110.82, 26.44, 334.74),
         ['Location'] = vector3(-45.67, -1098.34, 26.42), -- Blip Location
         ['ReturnLocation'] = vector3(-44.74, -1082.58, 26.68), -- Location to return vehicle, only enables if the vehicleshop has a job owned
         ['VehicleSpawn'] = vector4(-56.79, -1109.85, 26.43, 71.5), -- Spawn location when vehicle is bought
@@ -95,19 +95,18 @@ Config.Shops = {
         ['Type'] = 'managed', -- meaning a real player has to sell the car
         ['Zone'] = {
             ['Shape'] = {
-                vector2(-1260.6973876953, -349.21334838867),
-                vector2(-1268.6248779297, -352.87365722656),
-                vector2(-1274.1533203125, -358.29794311523),
-                vector2(-1273.8425292969, -362.73715209961),
-                vector2(-1270.5701904297, -368.6716003418),
-                vector2(-1266.0561523438, -375.14080810547),
-                vector2(-1244.3684082031, -362.70278930664),
-                vector2(-1249.8704833984, -352.03326416016),
-                vector2(-1252.9503173828, -345.85726928711)
+                vector3(-1260.6973876953, -349.21334838867, 36.91),
+                vector3(-1268.6248779297, -352.87365722656, 36.91),
+                vector3(-1274.1533203125, -358.29794311523, 36.91),
+                vector3(-1273.8425292969, -362.73715209961, 36.91),
+                vector3(-1270.5701904297, -368.6716003418, 36.91),
+                vector3(-1266.0561523438, -375.14080810547, 36.91),
+                vector3(-1244.3684082031, -362.70278930664, 36.91),
+                vector3(-1249.8704833984, -352.03326416016, 36.91),
+                vector3(-1252.9503173828, -345.85726928711, 36.91)
             },
-            ['minZ'] = 36.646457672119,
-            ['maxZ'] = 37.516143798828,
-            ['size'] = 2.75 -- size of the vehicles zones
+            ['size'] = vector3(3, 3, 4), -- size of the vehicles zones (x, y, z)
+            ['debug'] = false
         },
         ['Job'] = 'cardealer', -- Name of job or none
         ['ShopLabel'] = 'Luxury Vehicle Shop',
@@ -119,6 +118,7 @@ Config.Shops = {
             ['sports'] = 'Sports'
         },
         ['TestDriveTimeLimit'] = 0.5,
+        ['TestDriveReturnLocation'] = vector4(-1261.56, -347.54, 36.83, 216.22),
         ['Location'] = vector3(-1255.6, -361.16, 36.91),
         ['ReturnLocation'] = vector3(-1231.46, -349.86, 37.33),
         ['VehicleSpawn'] = vector4(-1231.46, -349.86, 37.33, 26.61),
@@ -160,14 +160,13 @@ Config.Shops = {
         ['Type'] = 'free-use', -- no player interaction is required to purchase a vehicle
         ['Zone'] = {
             ['Shape'] = {--polygon that surrounds the shop
-                vector2(-729.39, -1315.84),
-                vector2(-766.81, -1360.11),
-                vector2(-754.21, -1371.49),
-                vector2(-716.94, -1326.88)
+                vector3(-729.39, -1315.84, 0),
+                vector3(-766.81, -1360.11, 0),
+                vector3(-754.21, -1371.49, 0),
+                vector3(-716.94, -1326.88, 0)
             },
-            ['minZ'] = 0.0, -- min height of the shop zone
-            ['maxZ'] = 5.0, -- max height of the shop zone
-            ['size'] = 6.2 -- size of the vehicles zones
+            ['size'] = vector3(8, 8, 6), -- size of the vehicles zones
+            ['debug'] = true
         },
         ['Job'] = 'none', -- Name of job or none
         ['ShopLabel'] = 'Marina Shop', -- Blip name
@@ -178,28 +177,29 @@ Config.Shops = {
             ['boats'] = 'Boats'
         },
         ['TestDriveTimeLimit'] = 1.5, -- Time in minutes until the vehicle gets deleted
+        ['TestDriveReturnLocation'] = vector4(-733.19, -1313.45, 5.0, 226.37),
         ['Location'] = vector3(-738.25, -1334.38, 1.6), -- Blip Location
         ['ReturnLocation'] = vector3(-714.34, -1343.31, 0.0), -- Location to return vehicle, only enables if the vehicleshop has a job owned
         ['VehicleSpawn'] = vector4(-727.87, -1353.1, -0.17, 137.09), -- Spawn location when vehicle is bought
         ['TestDriveSpawn'] = vector4(-722.23, -1351.98, 0.14, 135.33), -- Spawn location for test drive
         ['ShowroomVehicles'] = {
             [1] = {
-                coords = vector4(-727.05, -1326.59, 0.00, 229.5), -- where the vehicle will spawn on display
+                coords = vector4(-727.05, -1326.59, 3.0, 229.5), -- where the vehicle will spawn on display
                 defaultVehicle = 'seashark', -- Default display vehicle
                 chosenVehicle = 'seashark' -- Same as default but is dynamically changed when swapping vehicles
             },
             [2] = {
-                coords = vector4(-732.84, -1333.5, -0.50, 229.5),
+                coords = vector4(-732.84, -1333.5, 3.0, 229.5),
                 defaultVehicle = 'dinghy',
                 chosenVehicle = 'dinghy'
             },
             [3] = {
-                coords = vector4(-737.84, -1340.83, -0.50, 229.5),
+                coords = vector4(-737.84, -1340.83, 3.0, 229.5),
                 defaultVehicle = 'speeder',
                 chosenVehicle = 'speeder'
             },
             [4] = {
-                coords = vector4(-741.53, -1349.7, -2.00, 229.5),
+                coords = vector4(-741.53, -1349.7, 3.0, 229.5),
                 defaultVehicle = 'marquis',
                 chosenVehicle = 'marquis'
             },
@@ -209,14 +209,13 @@ Config.Shops = {
         ['Type'] = 'free-use', -- no player interaction is required to purchase a vehicle
         ['Zone'] = {
             ['Shape'] = {--polygon that surrounds the shop
-                vector2(-1607.58, -3141.7),
-                vector2(-1672.54, -3103.87),
-                vector2(-1703.49, -3158.02),
-                vector2(-1646.03, -3190.84)
+                vector3(-1607.58, -3141.7, 12.99),
+                vector3(-1672.54, -3103.87, 12.99),
+                vector3(-1703.49, -3158.02, 12.99),
+                vector3(-1646.03, -3190.84, 12.99)
             },
-            ['minZ'] = 12.99, -- min height of the shop zone
-            ['maxZ'] = 16.99, -- max height of the shop zone
-            ['size'] = 7.0, -- size of the vehicles zones
+            ['size'] = vector3(10, 10, 8), -- size of the vehicles zones
+            ['debug'] = true
         },
         ['Job'] = 'none', -- Name of job or none
         ['ShopLabel'] = 'Air Shop', -- Blip name
@@ -228,6 +227,7 @@ Config.Shops = {
             ['planes'] = 'Planes'
         },
         ['TestDriveTimeLimit'] = 1.5, -- Time in minutes until the vehicle gets deleted
+        ['TestDriveReturnLocation'] = vector4(-1639.39, -3120.24, 13.94, 148.31),
         ['Location'] = vector3(-1652.76, -3143.4, 13.99), -- Blip Location
         ['ReturnLocation'] = vector3(-1628.44, -3104.7, 13.94), -- Location to return vehicle, only enables if the vehicleshop has a job owned
         ['VehicleSpawn'] = vector4(-1617.49, -3086.17, 13.94, 329.2), -- Spawn location when vehicle is bought

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,5 @@
 Config = {}
-Config.UsingTarget = GetConvar('UseTarget', 'false') == 'true'
+Config.UsingTarget = false
 Config.Commission = 0.10 -- Percent that goes to sales person from a full car sale 10%
 Config.FinanceCommission = 0.05 -- Percent that goes to sales person from a finance sale 5%
 Config.FinanceZone = vector3(-29.53, -1103.67, 26.42)-- Where the finance menu is located

--- a/config.lua
+++ b/config.lua
@@ -184,22 +184,22 @@ Config.Shops = {
         ['TestDriveSpawn'] = vector4(-722.23, -1351.98, 0.14, 135.33), -- Spawn location for test drive
         ['ShowroomVehicles'] = {
             [1] = {
-                coords = vector4(-727.05, -1326.59, 3.0, 229.5), -- where the vehicle will spawn on display
+                coords = vector4(-727.05, -1326.59, -0.50, 229.5), -- where the vehicle will spawn on display
                 defaultVehicle = 'seashark', -- Default display vehicle
                 chosenVehicle = 'seashark' -- Same as default but is dynamically changed when swapping vehicles
             },
             [2] = {
-                coords = vector4(-732.84, -1333.5, 3.0, 229.5),
+                coords = vector4(-732.84, -1333.5, -0.50, 229.5),
                 defaultVehicle = 'dinghy',
                 chosenVehicle = 'dinghy'
             },
             [3] = {
-                coords = vector4(-737.84, -1340.83, 3.0, 229.5),
+                coords = vector4(-737.84, -1340.83, -0.50, 229.5),
                 defaultVehicle = 'speeder',
                 chosenVehicle = 'speeder'
             },
             [4] = {
-                coords = vector4(-741.53, -1349.7, 3.0, 229.5),
+                coords = vector4(-741.53, -1349.7, -0.50, 229.5),
                 defaultVehicle = 'marquis',
                 chosenVehicle = 'marquis'
             },

--- a/config.lua
+++ b/config.lua
@@ -165,8 +165,8 @@ Config.Shops = {
                 vector3(-754.21, -1371.49, 0),
                 vector3(-716.94, -1326.88, 0)
             },
-            ['size'] = vector3(8, 8, 6), -- size of the vehicles zones
-            ['debug'] = true
+            ['size'] = vector3(8, 8, 6), -- size of the vehicles zones (x, y, z)
+            ['debug'] = false
         },
         ['Job'] = 'none', -- Name of job or none
         ['ShopLabel'] = 'Marina Shop', -- Blip name
@@ -214,8 +214,8 @@ Config.Shops = {
                 vector3(-1703.49, -3158.02, 12.99),
                 vector3(-1646.03, -3190.84, 12.99)
             },
-            ['size'] = vector3(10, 10, 8), -- size of the vehicles zones
-            ['debug'] = true
+            ['size'] = vector3(10, 10, 8), -- size of the vehicles zones (x, y, z)
+            ['debug'] = false
         },
         ['Job'] = 'none', -- Name of job or none
         ['ShopLabel'] = 'Air Shop', -- Blip name

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -12,11 +12,6 @@ shared_script {
 }
 
 client_scripts {
-    '@PolyZone/client.lua',
-    '@PolyZone/BoxZone.lua',
-    '@PolyZone/EntityZone.lua',
-    '@PolyZone/CircleZone.lua',
-    '@PolyZone/ComboZone.lua',
     'client.lua'
 }
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'qb-vehicleshop'
-version '2.0.0'
+version '2.0.1'
 
 shared_script {
     'config.lua',

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'qb-vehicleshop'
-version '2.0.1'
+version '2.0.0'
 
 shared_script {
     'config.lua',

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'qb-vehicleshop'
-version '2.0.0'
+version '1.0.0'
 
 shared_script {
     'config.lua',

--- a/locales/cs.lua
+++ b/locales/cs.lua
@@ -62,9 +62,9 @@ local Translations = {
         managed_sell_txt = "Prodej vozidlo hraci",
         managed_finance_txt = "Financovani vozidla",
         submit_ID = "Server ID (#)",
-        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        keypress_showFinanceMenu = "[E] Otvoriť ponuku Financie",
         --Floating
-        keypress_vehicleViewMenu = "[E] View Vehicle"
+        keypress_vehicleViewMenu = "[E] Zobraziť vozidlo"
     },
     general = {
         testdrive_timer = "Kolik zbyva do konce testovaci jizdy:",

--- a/locales/cs.lua
+++ b/locales/cs.lua
@@ -62,6 +62,9 @@ local Translations = {
         managed_sell_txt = "Prodej vozidlo hraci",
         managed_finance_txt = "Financovani vozidla",
         submit_ID = "Server ID (#)",
+        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        --Floating
+        keypress_vehicleViewMenu = "[E] View Vehicle"
     },
     general = {
         testdrive_timer = "Kolik zbyva do konce testovaci jizdy:",

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -62,9 +62,9 @@ local Translations = {
         managed_sell_txt = "Sell vehicle to Player",
         managed_finance_txt = "Finance vehicle to Player",
         submit_ID = "Server ID (#)",
-        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        keypress_showFinanceMenu = "[E] Menü Finanzen öffnen",
         --Floating
-        keypress_vehicleViewMenu = "[E] View Vehicle"
+        keypress_vehicleViewMenu = "[E] Fahrzeug ansehen"
     },
     general = {
         testdrive_timer = "Test Drive Time Remaining:",

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -62,6 +62,9 @@ local Translations = {
         managed_sell_txt = "Sell vehicle to Player",
         managed_finance_txt = "Finance vehicle to Player",
         submit_ID = "Server ID (#)",
+        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        --Floating
+        keypress_vehicleViewMenu = "[E] View Vehicle"
     },
     general = {
         testdrive_timer = "Test Drive Time Remaining:",

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -65,6 +65,9 @@ local Translations = {
         managed_sell_txt = "Sell vehicle to Player",
         managed_finance_txt = "Finance vehicle to Player",
         submit_ID = "Server ID (#)",
+        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        --Floating
+        keypress_vehicleViewMenu = "[E] View Vehicle"
     },
     general = {
         testdrive_timer = "Test Drive Time Remaining:",

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -63,9 +63,9 @@ local Translations = {
         managed_sell_txt = "Vender vehículo a jugador",
         managed_finance_txt = "Financiar vehículo a jugador",
         submit_ID = "ID de servidor (#)",
-        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        keypress_showFinanceMenu = "[E] Abrir Menú Finanzas",
         --Floating
-        keypress_vehicleViewMenu = "[E] View Vehicle"
+        keypress_vehicleViewMenu = "[E] Ver vehículo"
     },
     general = {
         testdrive_timer = "Tiempo restante de prueba de manejo:",

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -63,6 +63,9 @@ local Translations = {
         managed_sell_txt = "Vender vehículo a jugador",
         managed_finance_txt = "Financiar vehículo a jugador",
         submit_ID = "ID de servidor (#)",
+        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        --Floating
+        keypress_vehicleViewMenu = "[E] View Vehicle"
     },
     general = {
         testdrive_timer = "Tiempo restante de prueba de manejo:",

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -63,9 +63,9 @@ local Translations = {
         managed_sell_txt = "Vendre ce véhicule à quelqu'un",
         managed_finance_txt = "Faire financer ce véhicule",
         submit_ID = "ID du joueur (#)",
-        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        keypress_showFinanceMenu = "[E] Ouvrir le menu Finance",
         --Floating
-        keypress_vehicleViewMenu = "[E] View Vehicle"
+        keypress_vehicleViewMenu = "[E] Voir le véhicule"
     },
     general = {
         testdrive_timer = "Temps restant: ",

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -63,6 +63,9 @@ local Translations = {
         managed_sell_txt = "Vendre ce véhicule à quelqu'un",
         managed_finance_txt = "Faire financer ce véhicule",
         submit_ID = "ID du joueur (#)",
+        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        --Floating
+        keypress_vehicleViewMenu = "[E] View Vehicle"
     },
     general = {
         testdrive_timer = "Temps restant: ",

--- a/locales/hu.lua
+++ b/locales/hu.lua
@@ -1,0 +1,86 @@
+local Translations = {
+    error = {
+        testdrive_alreadyin = "Már próbaút alatt van",
+        testdrive_return = "Ez nem a te próbajárműved",
+        Invalid_ID = "Érvénytelen Játékos ID",
+        playertoofar = "A játékos nincs elég közel hozzád",
+        notenoughmoney = "Nincs elegendő pénzed",
+        minimumallowed = "Minimum befizetés $", --Minimum payment allowed is $ hogy a kurva anyámba mondod ezt magyarul geci
+        overpaid = "Túlfizettél",
+        alreadypaid = "A jármű már kivan fizetve",
+        notworth = "Nem ér annyit a jármű",
+        downtoosmall = "Az előleg összege túl kicsi",
+        exceededmax = "Túl lépte a maximális kifizetési összeget", -- hibás
+        repossessed = "A te %{plate} rendszámú járműved visszafoglalásra került",
+        buyerinfo = "Nem sikerült megszerezni a vásárló adatait",
+        notinveh = "Eladáshoz a járműben kell tartózkodnod",
+        vehinfo = "A jármű információk nem elérhetőek",
+        notown = "Ez a jármű nem a te birtokodban áll",
+        buyertoopoor = "A vásárlónak nem áll rendelkezésre elegendő fizető eszköze",
+        nofinanced = "Nincsen hitelezett járműved",
+        financed = "Ez a jármű hitelezett",
+    },
+    success = {
+        purchased = "Gratulálunk a vásárláshoz!",
+        earned_commission = "$ %{amount} jutalékot kerestél",
+        gifted = "Elajándékoztad a járműved",
+        received_gift = "Ajándékba kaptál egy járművet",
+        soldfor = "Eladtad a járműved $",
+        boughtfor = "Vásároltál egy járművet $",
+    },
+    menus = {
+        vehHeader_header = "Jármű lehetőségek",
+        vehHeader_txt = "Interakció a jelenlegi járművel",
+        financed_header = "Hitelezett járművek",
+        finance_txt = "Keresés a saját járművek között",
+        returnTestDrive_header = "Teszt vezetés befejezése",
+        categories_header = "Kategoriák",
+        goback_header = "Visszalépés",
+        veh_price = "Ár: $",
+        veh_platetxt = "Rendszám: ",
+        veh_finance = "Jármű fizetés",
+        veh_finance_balance = "Fennálló egyenleg",
+        veh_finance_currency = "$",
+        veh_finance_total = "Fennálló kifizetés",
+        veh_finance_reccuring = "Fizetendő részlet",
+        veh_finance_pay = "Fizetés",
+        veh_finance_payoff = "Jármű kifizetése",
+        veh_finance_payment = "Fizetendő összeg ($)",
+        submit_text = "Küldés",
+        test_header = "Teszt vezetés",
+        finance_header = "Jármű hitelezése",
+        owned_vehicles_header = "Birtokolt járművek",
+        swap_header = "Jármű csere",
+        swap_txt = "Az aktuálisan kiválaszott jármű cseréje",
+        financesubmit_downpayment = "Az előleg legalább - Min ",
+        financesubmit_totalpayment = "Teljes kifizetés - Max ",
+        --Free Use
+        freeuse_test_txt = "Jelenlegi jármű teszt vezetése",
+        freeuse_buy_header = "Jármű megvásárlása",
+        freeuse_buy_txt = "Kiválaszott jármű megvétele",
+        freeuse_finance_txt = "Kiválaszott jármű hitelezése",
+        --Managed
+        managed_test_txt = "Vásárló tesztvezetésének engedélyezése",
+        managed_sell_header = "Jármű eladás",
+        managed_sell_txt = "Kiválaszott jármű eladása",
+        managed_finance_txt = "Kiválaszott jármű hitelezése a vásárlónak",
+        submit_ID = "Idéglenes aktív személyiszám (#)",
+        keypress_showFinanceMenu = "[E] Hitelezési dokumentáció megnyitása",
+        --Floating
+        keypress_vehicleViewMenu = "[E] Jármű megnézése"
+    },
+    general = {
+        testdrive_timer = "Teszt vezetésből hátramaradt idő:",
+        vehinteraction = "Jármű interakció",
+        testdrive_timenoti = "%{testdrivetime} másodperced van még hátra",
+        testdrive_complete = "Tesztvezetés befejezése",
+        paymentduein = "A jármű törlesztőrészletének kifizetéséig %{time} perc van hátra",
+        command_transfervehicle = "Jármű eladása vagy elajándékozása",
+        command_transfervehicle_help = "Vásárló idéglenes aktív személyiszáma (ID)",
+        command_transfervehicle_amount = "Eladási ár (opcionális)",
+    }
+}
+Lang = Locale:new({
+    phrases = Translations,
+    warnOnMissing = true
+})

--- a/locales/hu.lua
+++ b/locales/hu.lua
@@ -65,7 +65,7 @@ local Translations = {
         managed_sell_txt = "Kiválaszott jármű eladása",
         managed_finance_txt = "Kiválaszott jármű hitelezése a vásárlónak",
         submit_ID = "Idéglenes aktív személyiszám (#)",
-        keypress_showFinanceMenu = "[E] Hitelezési dokumentáció megnyitása",
+        keypress_showFinanceMenu = "[E] Hitelezési menü megnyitása",
         --Floating
         keypress_vehicleViewMenu = "[E] Jármű megnézése"
     },

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -63,9 +63,9 @@ local Translations = {
         managed_sell_txt = "Verkoop voertuig aan speler",
         managed_finance_txt = "Financier voertuig aan speler",
         submit_ID = "Server ID (#)",
-        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        keypress_showFinanceMenu = "[E] Menu Financiën openen",
         --Floating
-        keypress_vehicleViewMenu = "[E] View Vehicle"
+        keypress_vehicleViewMenu = "[E] Bekijk voertuig"
     },
     general = {
         testdrive_timer = "Testrit tijd resterent:",

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -63,6 +63,9 @@ local Translations = {
         managed_sell_txt = "Verkoop voertuig aan speler",
         managed_finance_txt = "Financier voertuig aan speler",
         submit_ID = "Server ID (#)",
+        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        --Floating
+        keypress_vehicleViewMenu = "[E] View Vehicle"
     },
     general = {
         testdrive_timer = "Testrit tijd resterent:",

--- a/locales/ro.lua
+++ b/locales/ro.lua
@@ -67,6 +67,9 @@ local Translations = {
         managed_sell_txt = "Vinde vehiculul jcatorului",
         managed_finance_txt = "Vinde vehiculul in rate unui jucator",
         submit_ID = "ID-ul serverului (#)",
+        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        --Floating
+        keypress_vehicleViewMenu = "[E] View Vehicle"
     },
     general = {
         testdrive_timer = "Timp ramas pentru testare:",

--- a/locales/ro.lua
+++ b/locales/ro.lua
@@ -67,9 +67,9 @@ local Translations = {
         managed_sell_txt = "Vinde vehiculul jcatorului",
         managed_finance_txt = "Vinde vehiculul in rate unui jucator",
         submit_ID = "ID-ul serverului (#)",
-        keypress_showFinanceMenu = "[E] Open Finance Menu",
+        keypress_showFinanceMenu = "[E] Deschideți meniul Finanțe",
         --Floating
-        keypress_vehicleViewMenu = "[E] View Vehicle"
+        keypress_vehicleViewMenu = "[E] Vezi vehiculul"
     },
     general = {
         testdrive_timer = "Timp ramas pentru testare:",


### PR DESCRIPTION
Contents:

- Polyzone removed and swapped with ox.zone
- Targeting menu fixed
- Floating menu appears near a vehicle instead of an instant menu (press [E])
- localization included in english to all languages
- Hungarian locale included
- Test drive no longer creates return zone. I removed it due to a bug and makes no sense anyway because the player can't see the zone where return would take place.
- Test drive no longer returns player to the last location due to a bug that breaks the vehicleshop instead by default it will return the player front of the shop.
- Config got the following settings: zone debug for all shops, zone size change for all shops (vec3), test drive return location

Note: 3 people tested it including me. However bugs can be still present.

Known Bugs:
- If you set the Test drive return location inside the shop the script sometimes breaks (that is why i removed the last position)