### PR TITLE
feat: swapping vehicle no longer opens vehicle menu

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -586,11 +586,6 @@ AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
     init()
 end)
 
---- Opens the vehicleshop menu
-RegisterNetEvent('qb-vehicleshop:client:homeMenu', function()
-    openVehicleSellMenu()
-end)
-
 --- Starts the test drive. If vehicle parameter is not provided then the test drive will start with the closest vehicle to the player.
 --- @param vehicle number
 RegisterNetEvent('qb-vehicleshop:client:TestDrive', function(vehicle)

--- a/server.lua
+++ b/server.lua
@@ -126,10 +126,7 @@ end)
 -- Sync vehicle for other players
 ---@param data unknown
 RegisterNetEvent('qb-vehicleshop:server:swapVehicle', function(data)
-    local src = source
     TriggerClientEvent('qb-vehicleshop:client:swapVehicle', -1, data)
-    Wait(1500)-- let new car spawn
-    TriggerClientEvent('qb-vehicleshop:client:homeMenu', src)-- reopen main menu
 end)
 
 -- Send customer for test drive


### PR DESCRIPTION
## Description

- changes behavior of vehicle swapping within a shop to no longer re-open the vehicle menu. I think this is a better user experience as the player likely wants to look at the vehicle and will likely close the menu after swapping anyway.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
