### PR TITLE
refactor: car to shop map moved from core

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -206,8 +206,8 @@ local function openVehCatsMenu(category)
 
     for k, v in pairs(QBCore.Shared.Vehicles) do
         if QBCore.Shared.Vehicles[k].category == category then
-            if type(QBCore.Shared.Vehicles[k].shop) == 'table' then
-                for _, shop in pairs(QBCore.Shared.Vehicles[k].shop) do
+            if type(Config.Vehicles[k].shop) == 'table' then
+                for _, shop in pairs(Config.Vehicles[k].shop) do
                     if shop == InsideShop then
                         vehMenu[#vehMenu + 1] = {
                             title = v.brand..' '..v.name,
@@ -221,7 +221,7 @@ local function openVehCatsMenu(category)
                         }
                     end
                 end
-            elseif QBCore.Shared.Vehicles[k].shop == InsideShop then
+            elseif Config.Vehicles[k].shop == InsideShop then
                 vehMenu[#vehMenu + 1] = {
                     title = v.brand..' '..v.name,
                     description = Lang:t('menus.veh_price') .. v.price,

--- a/config.lua
+++ b/config.lua
@@ -260,3 +260,1541 @@ Config.Shops = {
         },
     },
 }
+Config.Vehicles = {
+    asbo = {
+		shop = 'pdm',
+	},
+	blista = {
+		shop = 'pdm',
+	},
+	brioso = {
+		shop = 'pdm',
+	},
+	club = {
+		shop = 'pdm',
+	},
+	dilettante = {
+		shop = 'pdm',
+	},
+	dilettante2 = {
+		shop = 'pdm',
+	},
+	kanjo = {
+		shop = 'pdm',
+	},
+	issi2 = {
+		shop = 'pdm',
+	},
+	issi3 = {
+		shop = 'pdm',
+	},
+	issi4 = {							--DLC
+		shop = 'pdm',
+	},
+	issi5 = {							--DLC
+		shop = 'pdm',
+	},
+	issi6 = {							--DLC
+		shop = 'pdm',
+	},
+	panto = {
+		shop = 'pdm',
+	},
+	prairie = {
+		shop = 'pdm',
+	},
+	rhapsody = {
+		shop = 'pdm',
+	},
+	brioso2 = {
+		shop = 'pdm',
+	},
+	weevil = {
+		shop = 'pdm',
+	},
+	--- Coupes
+	cogcabrio = {
+		shop = 'pdm',
+	},
+	exemplar = {
+		shop = 'pdm',
+	},
+	f620 = {
+		shop = 'pdm',
+	},
+	felon = {
+		shop = 'pdm',
+	},
+	felon2 = {
+		shop = 'pdm',
+	},
+	jackal = {
+		shop = 'pdm',
+	},
+	oracle = {
+		shop = 'pdm',
+	},
+	oracle2 = {
+		shop = 'pdm',
+	},
+	sentinel = {
+		shop = 'pdm',
+	},
+	sentinel2 = {
+		shop = 'pdm',
+	},
+	windsor = {
+		shop = 'pdm',
+	},
+	windsor2 = {
+		shop = 'pdm',
+	},
+	zion = {
+		shop = 'pdm',
+	},
+	zion2 = {
+		shop = 'pdm',
+	},
+	previon = {			--DLC +set sv_enforceGameBuild 2372
+		shop = 'pdm',
+	},
+	champion = {		--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	ignus = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	zeno = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	--- Cycles
+	bmx = {
+		shop = 'pdm',
+	},
+	cruiser = {
+		shop = 'pdm',
+	},
+	fixter = {
+		shop = 'pdm',
+	},
+	scorcher = {
+		shop = 'pdm',
+	},
+	tribike = {
+		shop = 'pdm',
+	},
+	tribike2 = {
+		shop = 'pdm',
+	},
+	tribike3 = {
+		shop = 'pdm',
+	},
+	--- Motorcycles
+	akuma = {
+		shop = 'pdm',
+	},
+	avarus = {
+		shop = 'pdm',
+	},
+	bagger = {
+		shop = 'pdm',
+	},
+	bati = {
+		shop = 'pdm',
+	},
+	bati2 = {
+		shop = 'pdm',
+	},
+	bf400 = {
+		shop = 'pdm',
+	},
+	carbonrs = {
+		shop = 'pdm',
+	},
+	chimera = {
+		shop = 'pdm',
+	},
+	cliffhanger = {
+		shop = 'pdm',
+	},
+	daemon = {
+		shop = 'pdm',
+	},
+	daemon2 = {
+		shop = 'pdm',
+	},
+	defiler = {
+		shop = 'pdm',
+	},
+	deathbike = {							--DLC
+		shop = 'pdm',
+	},
+	deathbike2 = {							--DLC
+		shop = 'pdm',
+	},
+	deathbike3 = {							--DLC
+		shop = 'pdm',
+	},
+	diablous = {
+		shop = 'pdm',
+	},
+	diablous2 = {
+		shop = 'pdm',
+	},
+	double = {
+		shop = 'pdm',
+	},
+	enduro = {
+		shop = 'pdm',
+	},
+	esskey = {
+		shop = 'pdm',
+	},
+	faggio = {
+		shop = 'pdm',
+	},
+	faggio2 = {
+		shop = 'pdm',
+	},
+	faggio3 = {
+		shop = 'pdm',
+	},
+	fcr = {
+		shop = 'pdm',
+	},
+	fcr2 = {
+		shop = 'pdm',
+	},
+	gargoyle = {
+		shop = 'pdm',
+	},
+	hakuchou = {
+		shop = 'pdm',
+	},
+	hakuchou2 = {
+		shop = 'pdm',
+	},
+	hexer = {
+		shop = 'pdm',
+	},
+	innovation = {
+		shop = 'pdm',
+	},
+	lectro = {
+		shop = 'pdm',
+	},
+	manchez = {
+		shop = 'pdm',
+	},
+	nemesis = {
+		shop = 'pdm',
+	},
+	nightblade = {
+		shop = 'pdm',
+	},
+	oppressor = {
+		shop = 'luxury',
+	},
+	pcj = {
+		shop = 'pdm',
+	},
+	ratbike = {
+		shop = 'pdm',
+	},
+	ruffian = {
+		shop = 'pdm',
+	},
+	sanchez = {
+		shop = 'pdm',
+	},
+	sanchez2 = {
+		shop = 'pdm',
+	},
+	sanctus = {
+		shop = 'pdm',
+	},
+	shotaro = {
+		shop = 'pdm',
+	},
+	sovereign = {
+		shop = 'pdm',
+	},
+	stryder = {
+		shop = 'pdm',
+	},
+	thrust = {
+		shop = 'pdm',
+	},
+	vader = {
+		shop = 'pdm',
+	},
+	vindicator = {
+		shop = 'pdm',
+	},
+	vortex = {
+		shop = 'pdm',
+	},
+	wolfsbane = {
+		shop = 'pdm',
+	},
+	zombiea = {
+		shop = 'pdm',
+	},
+	zombieb = {
+		shop = 'pdm',
+	},
+	manchez2 = {
+		shop = 'pdm',
+	},
+	shinobi = {		--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	reever = {		--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	--- Muscle
+	blade = {
+		shop = 'pdm',
+	},
+	buccaneer = {
+		shop = 'pdm',
+	},
+	buccaneer2 = {
+		shop = 'pdm',
+	},
+	chino = {
+		shop = 'pdm',
+	},
+	chino2 = {
+		shop = 'pdm',
+	},
+	clique = {							--DLC
+		shop = 'pdm',
+	},
+	coquette3 = {
+		shop = 'pdm',
+	},
+	deviant = {							--DLC
+		shop = 'pdm',
+	},
+	dominator = {
+		shop = 'pdm',
+	},
+	dominator2 = {
+		shop = 'pdm',
+	},
+	dominator3 = {
+		shop = 'pdm',
+	},
+	dominator4 = {							--DLC
+		shop = 'pdm',
+	},
+	dominator7 = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'pdm',
+	},
+	dominator8 = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'pdm',
+	},
+	dukes = {
+		shop = 'pdm',
+	},
+	dukes2 = {
+		shop = 'pdm',
+	},
+	dukes3 = {
+		shop = 'pdm',
+	},
+	faction = {
+		shop = 'pdm',
+	},
+	faction2 = {
+		shop = 'pdm',
+	},
+	faction3 = {
+		shop = 'pdm',
+	},
+	ellie = {
+		shop = 'pdm',
+	},
+	gauntlet = {
+		shop = 'pdm',
+	},
+	gauntlet2 = {
+		shop = 'pdm',
+	},
+	gauntlet3 = {							--DLC
+		shop = 'pdm',
+	},
+	gauntlet4 = {							--DLC
+		shop = 'pdm',
+	},
+	gauntlet5 = {
+		shop = 'pdm',
+	},
+	hermes = {
+		shop = 'pdm',
+	},
+	hotknife = {
+		shop = 'pdm',
+	},
+	hustler = {
+		shop = 'pdm',
+	},
+	impaler = {							--DLC
+		shop = 'pdm',
+	},
+	impaler2 = {							--DLC
+		shop = 'pdm',
+	},
+	impaler3 = {							--DLC
+		shop = 'pdm',
+	},
+	impaler4 = {							--DLC
+		shop = 'pdm',
+	},
+	imperator = {							--DLC
+		shop = 'pdm',
+	},
+	imperator2 = {							--DLC
+		shop = 'pdm',
+	},
+	imperator3 = {							--DLC
+		shop = 'pdm',
+	},
+	lurcher = {
+		shop = 'pdm',
+	},
+	moonbeam = {
+		shop = 'pdm',
+	},
+	moonbeam2 = {
+		shop = 'pdm',
+	},
+	nightshade = {
+		shop = 'pdm',
+	},
+	peyote2 = {							--DLC
+		shop = 'pdm',
+	},
+	phoenix = {
+		shop = 'pdm',
+	},
+	picador = {
+		shop = 'pdm',
+	},
+	ratloader2 = {
+		shop = 'pdm',
+	},
+	ruiner = {
+		shop = 'pdm',
+	},
+	ruiner2 = {
+		shop = 'pdm',
+	},
+	sabregt = {
+		shop = 'pdm',
+	},
+	sabregt2 = {
+		shop = 'pdm',
+	},
+	slamvan = {
+		shop = 'pdm',
+	},
+	slamvan2 = {
+		shop = 'pdm',
+	},
+	slamvan3 = {
+		shop = 'pdm',
+	},
+	stalion = {
+		shop = 'pdm',
+	},
+	stalion2 = {
+		shop = 'pdm',
+	},
+	tampa = {
+		shop = 'pdm',
+	},
+	tulip = {							--DLC
+		shop = 'pdm',
+	},
+	vamos = {							--DLC
+		shop = 'pdm',
+	},
+	vigero = {
+		shop = 'pdm',
+	},
+	virgo = {
+		shop = 'pdm',
+	},
+	virgo2 = {
+		shop = 'pdm',
+	},
+	virgo3 = {
+		shop = 'pdm',
+	},
+	voodoo = {
+		shop = 'pdm',
+	},
+	yosemite = {
+		shop = 'pdm',
+	},
+	yosemite2 = {
+		shop = 'pdm',
+	},
+	yosemite3 = {
+		shop = 'pdm',
+	},
+	buffalo4 = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	--- Off-Road
+	bfinjection = {
+		shop = 'pdm',
+	},
+	bifta = {
+		shop = 'pdm',
+	},
+	blazer = {
+		shop = 'pdm',
+	},
+	blazer2 = {
+		shop = 'pdm',
+	},
+	blazer3 = {
+		shop = 'pdm',
+	},
+	blazer4 = {
+		shop = 'pdm',
+	},
+	blazer5 = {
+		shop = 'pdm',
+	},
+	brawler = {
+		shop = 'pdm',
+	},
+	caracara = {
+		shop = 'pdm',
+	},
+	caracara2 = {							--DLC
+		shop = 'pdm',
+	},
+	dubsta3 = {
+		shop = 'pdm',
+	},
+	dune = {
+		shop = 'pdm',
+	},
+	everon = {
+		shop = 'pdm',
+	},
+	freecrawler = {							--DLC
+		shop = 'pdm',
+	},
+	hellion = {							--DLC
+		shop = 'pdm',
+	},
+	kalahari = {
+		shop = 'pdm',
+	},
+	kamacho = {
+		shop = 'pdm',
+	},
+	mesa3 = {
+		shop = 'pdm',
+	},
+	outlaw = {
+		shop = 'pdm',
+	},
+	rancherxl = {
+		shop = 'pdm',
+	},
+	rebel2 = {
+		shop = 'pdm',
+	},
+	riata = {
+		shop = 'pdm',
+	},
+	sandking = {
+		shop = 'pdm',
+	},
+	sandking2 = {
+		shop = 'pdm',
+	},
+	trophytruck = {
+		shop = 'pdm',
+	},
+	trophytruck2 = {
+		shop = 'pdm',
+	},
+	vagrant = {
+		shop = 'pdm',
+	},
+	verus = {
+		shop = 'pdm',
+	},
+	winky = {
+		shop = 'pdm',
+	},
+	--- SUVs
+	baller = {
+		shop = 'pdm',
+	},
+	baller2 = {
+		shop = 'pdm',
+	},
+	baller3 = {
+		shop = 'pdm',
+	},
+	baller4 = {
+		shop = 'pdm',
+	},
+	baller5 = {
+		shop = 'pdm',
+	},
+	baller6 = {
+		shop = 'pdm',
+	},
+	bjxl = {
+		shop = 'pdm',
+	},
+	cavalcade = {
+		shop = 'pdm',
+	},
+	cavalcade2 = {
+		shop = 'pdm',
+	},
+	contender = {
+		shop = 'pdm',
+	},
+	dubsta = {
+		shop = 'pdm',
+	},
+	dubsta2 = {
+		shop = 'pdm',
+	},
+	fq2 = {
+		shop = 'pdm',
+	},
+	granger = {
+		shop = 'pdm',
+	},
+	gresley = {
+		shop = 'pdm',
+	},
+	habanero = {
+		shop = 'pdm',
+	},
+	huntley = {
+		shop = 'pdm',
+	},
+	landstalker = {
+		shop = 'pdm',
+	},
+	landstalker2 = {
+		shop = 'pdm',
+	},
+	mesa = {
+		shop = 'pdm',
+	},
+	novak = {							--DLC
+		shop = 'pdm',
+	},
+	patriot = {
+		shop = 'pdm',
+	},
+	radi = {
+		shop = 'pdm',
+	},
+	rebla = {
+		shop = 'pdm',
+	},
+	rocoto = {
+		shop = 'pdm',
+	},
+	seminole = {
+		shop = 'pdm',
+	},
+	seminole2 = {
+		shop = 'pdm',
+	},
+	serrano = {
+		shop = 'pdm',
+	},
+	toros = {							--DLC
+		shop = 'pdm',
+	},
+	xls = {
+		shop = 'pdm',
+	},
+	granger2 = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	--- Sedans
+	asea = {
+		shop = 'pdm',
+	},
+	asterope = {
+		shop = 'pdm',
+	},
+	cog55 = {
+		shop = 'pdm',
+	},
+	cognoscenti = {
+		shop = 'pdm',
+	},
+	emperor = {
+		shop = 'pdm',
+	},
+	fugitive = {
+		shop = 'pdm',
+	},
+	glendale = {
+		shop = 'pdm',
+	},
+	glendale2 = {
+		shop = 'pdm',
+	},
+	ingot = {
+		shop = 'pdm',
+	},
+	intruder = {
+		shop = 'pdm',
+	},
+	premier = {
+		shop = 'pdm',
+	},
+	primo = {
+		shop = 'pdm',
+	},
+	primo2 = {
+		shop = 'pdm',
+	},
+	regina = {
+		shop = 'pdm',
+	},
+	stafford = {							--DLC
+		shop = 'pdm',
+	},
+	stanier = {
+		shop = 'pdm',
+	},
+	stratum = {
+		shop = 'pdm',
+	},
+	stretch = {
+		shop = 'pdm',
+	},
+	superd = {
+		shop = 'pdm',
+	},
+	surge = {
+		shop = 'pdm',
+	},
+	tailgater = {
+		shop = 'pdm',
+	},
+	warrener = {
+		shop = 'pdm',
+	},
+	washington = {
+		shop = 'pdm',
+	},
+	tailgater2 = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'pdm',
+	},
+	cinquemila = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	iwagen = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	astron = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	baller7 = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	comet7 = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	deity = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	jubilee = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	patriot3 = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	--- Sports
+	alpha = {
+		shop = 'luxury',
+	},
+	banshee = {
+		shop = 'luxury',
+	},
+	bestiagts = {
+		shop = 'luxury',
+	},
+	blista2 = {
+		shop = 'pdm',
+	},
+	blista3 = {
+		shop = 'pdm',
+	},
+	buffalo = {
+		shop = 'luxury',
+	},
+	buffalo2 = {
+		shop = 'luxury',
+	},
+	carbonizzare = {
+		shop = 'luxury',
+	},
+	comet2 = {
+		shop = 'luxury',
+	},
+	comet3 = {
+		shop = 'luxury',
+	},
+	comet4 = {
+		shop = 'luxury',
+	},
+	comet5 = {
+		shop = 'luxury',
+	},
+	coquette = {
+		shop = 'luxury',
+	},
+	coquette2 = {
+		shop = 'pdm',
+	},
+	coquette4 = {
+		shop = 'luxury',
+	},
+	drafter = {							--DLC
+		shop = 'luxury',
+	},
+	deveste = {							--DLC
+		shop = 'luxury',
+	},
+	elegy = {							--DLC
+		shop = 'luxury',
+	},
+	elegy2 = {
+		shop = 'luxury',
+	},
+	feltzer2 = {
+		shop = 'luxury',
+	},
+	flashgt = {
+		shop = 'luxury',
+	},
+	furoregt = {
+		shop = 'luxury',
+	},
+	futo = {
+		shop = 'pdm',
+	},
+	gb200 = {
+		shop = 'luxury',
+	},
+	komoda = {
+		shop = 'luxury',
+	},
+	imorgon = {
+		shop = 'luxury',
+	},
+	issi7 = {							--DLC
+		shop = 'pdm',
+	},
+	italigto = {							--DLC
+		shop = 'luxury',
+	},
+	jugular = {							--DLC
+		shop = 'luxury',
+	},
+	jester = {
+		shop = 'luxury',
+	},
+	jester2 = {
+		shop = 'luxury',
+	},
+	jester3 = {
+		shop = 'luxury',
+	},
+	khamelion = {
+		shop = 'luxury',
+	},
+	kuruma = {
+		shop = 'luxury',
+	},
+	kuruma2 = {
+		shop = 'luxury',
+	},
+	locust = {							--DLC
+		shop = 'luxury',
+	},
+	lynx = {
+		shop = 'luxury',
+	},
+	massacro = {
+		shop = 'luxury',
+	},
+	massacro2 = {
+		shop = 'luxury',
+	},
+	neo = {							--DLC
+		shop = 'luxury',
+	},
+	neon = {							--DLC
+		shop = 'luxury',
+	},
+	ninef = {
+		shop = 'luxury',
+	},
+	ninef2 = {
+		shop = 'luxury',
+	},
+	omnis = {
+		shop = 'luxury',
+	},
+	paragon = {							--DLC
+		shop = 'luxury',
+	},
+	pariah = {
+		shop = 'luxury',
+	},
+	penumbra = {
+		shop = 'luxury',
+	},
+	penumbra2 = {
+		shop = 'luxury',
+	},
+	rapidgt = {
+		shop = 'luxury',
+	},
+	rapidgt2 = {
+		shop = 'luxury',
+	},
+	raptor = {
+		shop = 'luxury',
+	},
+	revolter = {
+		shop = 'luxury',
+	},
+	ruston = {
+		shop = 'luxury',
+	},
+	schafter2 = {
+		shop = 'pdm',
+	},
+	schafter3 = {
+		shop = 'luxury',
+	},
+	schafter4 = {
+		shop = 'luxury',
+	},
+	schlagen = {							--DLC
+		shop = 'luxury',
+	},
+	schwarzer = {
+		shop = 'luxury',
+	},
+	sentinel3 = {
+		shop = 'pdm',
+	},
+	seven70 = {
+		shop = 'luxury',
+	},
+	specter = {
+		shop = 'luxury',
+	},
+	streiter = {
+		shop = 'luxury',
+	},
+	sugoi = {
+		shop = 'luxury',
+	},
+	sultan = {
+		shop = 'luxury',
+	},
+	sultan2 = {
+		shop = 'luxury',
+	},
+	surano = {
+		shop = 'luxury',
+	},
+	tampa2 = {
+		shop = 'pdm',
+	},
+	tropos = {
+		shop = 'luxury',
+	},
+	verlierer2 = {
+		shop = 'luxury',
+	},
+	vstr = {
+		shop = 'luxury',
+	},
+	italirsx = {
+		shop = 'luxury',
+	},
+	zr350 = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	calico = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	futo2 = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	euros = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	jester4 = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	remus = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	comet6 = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	growler = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	vectre = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	cypher = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	sultan3 = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	rt3000 = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'luxury',
+	},
+	--- Sports Classic
+	ardent = {
+		shop = 'pdm',
+	},
+	btype = {              --meme car that goes pretty fast
+		shop = 'pdm',
+	},
+	btype2 = {
+		shop = 'pdm',
+	},
+	btype3 = {
+		shop = 'pdm',
+	},
+	casco = {
+		shop = 'pdm',
+	},
+	cheetah2 = {
+		shop = 'luxury',
+	},
+	deluxo = {
+		shop = 'pdm',
+	},
+	dynasty = {							--DLC
+		shop = 'pdm',
+	},
+	fagaloa = {
+		shop = 'pdm',
+	},
+	feltzer3 = {							--DLC
+		shop = 'pdm',
+	},
+	gt500 = {
+		shop = 'pdm',
+	},
+	infernus2 = {
+		shop = 'pdm',
+	},
+	jb700 = {
+		shop = 'pdm',
+	},
+	jb7002 = {
+		shop = 'pdm',
+	},
+	mamba = {
+		shop = 'pdm',
+	},
+	manana = {
+		shop = 'pdm',
+	},
+	manana2 = {
+		shop = 'pdm',
+	},
+	michelli = {
+		shop = 'pdm',
+	},
+	monroe = {
+		shop = 'pdm',
+	},
+	nebula = {							--DLC
+		shop = 'pdm',
+	},
+	peyote = {
+		shop = 'pdm',
+	},
+	peyote3 = {
+		shop = 'pdm',
+	},
+	pigalle = {
+		shop = 'pdm',
+	},
+	rapidgt3 = {
+		shop = 'pdm',
+	},
+	retinue = {
+		shop = 'pdm',
+	},
+	retinue2 = {
+		shop = 'pdm',
+	},
+	savestra = {
+		shop = 'pdm',
+	},
+	stinger = {
+		shop = 'pdm',
+	},
+	stingergt = {
+		shop = 'pdm',
+	},
+	stromberg = {
+		shop = 'pdm',
+	},
+	swinger = {							--DLC
+		shop = 'pdm',
+	},
+	torero = {
+		shop = 'pdm',
+	},
+	tornado = {
+		shop = 'pdm',
+	},
+	tornado2 = {
+		shop = 'pdm',
+	},
+	tornado5 = {
+		shop = 'pdm',
+	},
+	turismo2 = {
+		shop = 'pdm',
+	},
+	viseris = {
+		shop = 'pdm',
+	},
+	z190 = {
+		shop = 'pdm',
+	},
+	ztype = {
+		shop = 'pdm',
+	},
+	zion3 = {							--DLC
+		shop = 'pdm',
+	},
+	cheburek = {
+		shop = 'pdm',
+	},
+	toreador = {
+		shop = 'pdm',
+	},
+	--- Super
+	adder = {
+		shop = 'luxury',
+	},
+	autarch = {
+		shop = 'luxury',
+	},
+	banshee2 = {
+		shop = 'luxury',
+	},
+	bullet = {
+		shop = 'luxury',
+	},
+	cheetah = {
+		shop = 'luxury',
+	},
+	cyclone = {         --might be too overpowered
+		shop = 'luxury',
+	},
+	entity2 = {
+		shop = 'luxury',
+	},
+	entityxf = {
+		shop = 'luxury',
+	},
+	emerus = {							--DLC
+		shop = 'luxury',
+	},
+	fmj = {
+		shop = 'luxury',
+	},
+	furia = {
+		shop = 'luxury',
+	},
+	gp1 = {
+		shop = 'luxury',
+	},
+	infernus = {
+		shop = 'luxury',
+	},
+	italigtb = {
+		shop = 'luxury',
+	},
+	italigtb2 = {
+		shop = 'luxury',
+	},
+	krieger = {							--DLC
+		shop = 'luxury',
+	},
+	le7b = {
+		shop = 'luxury',
+	},
+	nero = {
+		shop = 'luxury',
+	},
+	nero2 = {
+		shop = 'luxury',
+	},
+	osiris = {
+		shop = 'luxury',
+	},
+	penetrator = {
+		shop = 'luxury',
+	},
+	pfister811 = {
+		shop = 'luxury',
+	},
+	prototipo = {
+		shop = 'luxury',
+	},
+	reaper = {
+		shop = 'luxury',
+	},
+	s80 = {							--DLC
+		shop = 'luxury',
+	},
+	sc1 = {
+		shop = 'luxury',
+	},
+	sheava = {							--DLC
+		shop = 'luxury',
+	},
+	sultanrs = {
+		shop = 'luxury',
+	},
+	t20 = {
+		shop = 'luxury',
+	},
+	taipan = {
+		shop = 'luxury',
+	},
+	tempesta = {
+		shop = 'luxury',
+	},
+	tezeract = {
+		shop = 'luxury',
+	},
+	thrax = {							--DLC
+		shop = 'luxury',
+	},
+	tigon = {
+		shop = 'luxury',
+	},
+	turismor = {
+		shop = 'luxury',
+	},
+	tyrant = {
+		shop = 'luxury',
+	},
+	tyrus = {
+		shop = 'luxury',
+	},
+	vacca = {
+		shop = 'luxury',
+	},
+	vagner = {
+		shop = 'luxury',
+	},
+	visione = {
+		shop = 'luxury',
+	},
+	voltic = {
+		shop = 'luxury',
+	},
+	voltic2 = {
+		shop = 'luxury',
+	},
+	xa21 = {
+		shop = 'luxury',
+	},
+	zentorno = {
+		shop = 'luxury',
+	},
+	zorrusso = {							--DLC
+		shop = 'luxury',
+	},
+	-- Vans
+	bison = {
+		shop = 'pdm',
+	},
+	bobcatxl = {
+		shop = 'pdm',
+	},
+	burrito3 = {
+		shop = 'pdm',
+	},
+	gburrito2 = {
+		shop = 'pdm',
+	},
+	rumpo = {
+		shop = 'pdm',
+	},
+	journey = {
+		shop = 'pdm',
+	},
+	minivan = {
+		shop = 'pdm',
+	},
+	minivan2 = {
+		shop = 'pdm',
+	},
+	paradise = {
+		shop = 'pdm',
+	},
+	rumpo3 = {
+		shop = 'pdm',
+	},
+	speedo = {
+		shop = 'pdm',
+	},
+	speedo4 = {
+		shop = 'pdm',
+	},
+	surfer = {
+		shop = 'pdm',
+	},
+	youga3 = {
+		shop = 'pdm',
+	},
+	youga = {
+		shop = 'pdm',
+	},
+	youga2 = {
+		shop = 'pdm',
+	},
+	youga4 = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	mule5 = { 	 	--DLC +set sv_enforceGameBuild 2545
+		shop = 'pdm',
+	},
+	-- Utility
+	sadler = {
+		shop = 'pdm',
+	},
+	guardian = {
+		shop = 'pdm',
+	},
+	slamtruck = {
+		shop = 'pdm',
+	},
+	warrener2 = {							--DLC +set sv_enforceGameBuild 2372
+		shop = 'pdm',
+	},
+		-- Boats
+	squalo = {
+		shop = 'boats',
+	},
+	marquis = {
+		shop = 'boats',
+	},
+	seashark = {
+		shop = 'boats',
+	},
+	seashark2 = {
+		shop = 'boats',
+	},
+	seashark3 = {
+		shop = 'boats',
+	},
+	jetmax = {
+		shop = 'boats',
+	},
+	tropic = {
+		shop = 'boats',
+	},
+	tropic2 = {
+		shop = 'boats',
+	},
+	dinghy = {
+		shop = 'boats',
+	},
+	dinghy2 = {
+		shop = 'boats',
+	},
+	dinghy3 = {
+		shop = 'boats',
+	},
+	dinghy4 = {
+		shop = 'boats',
+	},
+	suntrap = {
+		shop = 'boats',
+	},
+	speeder = {
+		shop = 'boats',
+	},
+	speeder2 = {
+		shop = 'boats',
+	},
+	longfin = {
+		shop = 'boats',
+	},
+	toro = {
+		shop = 'boats',
+	},
+	toro2 = {
+		shop = 'boats',
+	},
+	-- helicopters
+	buzzard2 = {
+		shop = 'air',
+	},
+	frogger = {
+		shop = 'air',
+	},
+	frogger2 = {
+		shop = 'air',
+	},
+	maverick = {
+		shop = 'air',
+	},
+	swift = {
+		shop = 'air',
+	},
+	swift2 = {
+		shop = 'air',
+	},
+	seasparrow = {
+		shop = 'air',
+	},
+	seasparrow2 = {
+		shop = 'air',
+	},
+	seasparrow3 = {
+		shop = 'air',
+	},
+	supervolito = {
+		shop = 'air',
+	},
+	supervolito2 = {
+		shop = 'air',
+	},
+	volatus = {
+		shop = 'air',
+	},
+	havok = {
+		shop = 'air',
+	},
+	-- Planes
+	duster = {
+		shop = 'air',
+	},
+	luxor = {
+		shop = 'air',
+	},
+	luxor2 = {
+		shop = 'air',
+	},
+	stunt = {
+		shop = 'air',
+	},
+	mammatus = {
+		shop = 'air',
+	},
+	velum = {
+		shop = 'air',
+	},
+	velum2 = {
+		shop = 'air',
+	},
+	shamal = {
+		shop = 'air',
+	},
+	vestra = {
+		shop = 'air',
+	},
+	dodo = {
+		shop = 'air',
+	},
+	howard = {
+		shop = 'air',
+	},
+	alphaz1 = {
+		shop = 'air',
+	},
+	nimbus = {
+		shop = 'air',
+	},
+	brioso3 = {          --DLC +set sv_enforceGameBuild 2699 (and below)
+        shop = 'pdm',
+    },
+    conada = {
+        shop = 'air',
+    },
+    corsita = {
+        shop = 'luxury',
+    },
+    draugur = {
+        shop = 'pdm',
+    },
+    greenwood = {
+        shop = 'pdm',
+    },
+    kanjosj = {
+        shop = 'pdm',
+    },
+    lm87 = {
+        shop = 'luxury',
+    },
+    omnisegt = {
+        shop = 'luxury',
+    },
+    postlude = {
+        shop = 'pdm',
+    },
+    rhinehart = {
+        shop = 'pdm',
+    },
+    ruiner4 = {
+        shop = 'pdm',
+    },
+    sentinel4 = {
+        shop = 'luxury',
+    },
+    sm722 = {
+        shop = 'luxury',
+    },
+	tenf = {
+        shop = 'luxury',
+    },
+    tenf2 = {
+        shop = 'luxury',
+    },
+    torero2 = {
+        shop = 'luxury',
+    },
+    vigero2 = {
+        shop = 'pdm',
+    },
+    weevil2 = {
+        shop = 'pdm',
+    },
+}


### PR DESCRIPTION
## Description

qbx-vehicleshop is the only resource (as far as I know) that cares about which shops cars are sold at. It seems like it should be the source of truth for this data rather than qbx-core.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
