### PR TITLE
feat: config options to disable financing and free use buying

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -350,24 +350,31 @@ local function openVehicleSellMenu()
                 args = {
                     vehicle = Config.Shops[InsideShop].ShowroomVehicles[closestVehicle].chosenVehicle
                 }
-            },
-            {
+            }
+        }
+
+        if Config.EnableFreeUseBuy then
+            options[#options+1] = {
                 title = Lang:t('menus.freeuse_buy_header'),
                 description = Lang:t('menus.freeuse_buy_txt'),
                 serverEvent = 'qb-vehicleshop:server:buyShowroomVehicle',
                 args = {
                     buyVehicle = Config.Shops[InsideShop].ShowroomVehicles[closestVehicle].chosenVehicle
                 }
-            },
-            {
+            }
+        end
+
+        if Config.EnableFinance then
+            options[#options+1] = {
                 title = Lang:t('menus.finance_header'),
                 description = Lang:t('menus.freeuse_finance_txt'),
                 onSelect = function()
                     openFinance(closestVehicle, Config.Shops[InsideShop].ShowroomVehicles[closestVehicle].chosenVehicle)
                 end
-            },
-            swapOption,
-        }
+            }
+        end
+
+        options[#options+1] = swapOption
     else
         options = {
             {
@@ -383,16 +390,20 @@ local function openVehicleSellMenu()
                 onSelect = function()
                     sellVehicle(Config.Shops[InsideShop].ShowroomVehicles[closestVehicle].chosenVehicle)
                 end,
-            },
-            {
+            }
+        }
+
+        if Config.EnableFinance then
+            options[#options+1] = {
                 title = Lang:t('menus.finance_header'),
                 description = Lang:t('menus.managed_finance_txt'),
                 onSelect = function()
                     openCustomFinance(closestVehicle)
                 end
-            },
-            swapOption,
-        }
+            }
+        end
+
+        options[#options+1] = swapOption
     end
 
     lib.registerContext({

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,8 @@
 Config = {}
 Config.UsingTarget = GetConvar('UseTarget', 'false') == 'true'
 Config.Commission = 0.10 -- Percent that goes to sales person from a full car sale 10%
+Config.EnableFinance = true -- allows financing new vehicles. Turning off does not affect already financed vehicles
+Config.EnableFreeUseBuy = true -- allows players to buy from NPC shops
 Config.FinanceCommission = 0.05 -- Percent that goes to sales person from a finance sale 5%
 Config.FinanceZone = vector3(-29.53, -1103.67, 26.42)-- Where the finance menu is located
 Config.PaymentWarning = 10 -- time in minutes that player has to make payment before repo


### PR DESCRIPTION
## Description

- new config options to disable financing of new vehicles and buying vehicles from NPC shops. Use case is a server that wants players to be able to view and test drive vehicles, but to purchase would require a player to sell them the vehicle.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
