### PR TITLE
refactor: finance menu and vehicle display

### DIFF
--- a/config/client.lua
+++ b/config/client.lua
@@ -89,7 +89,7 @@ return {
                 cycles = 'Bicycles'
             },
             testDrive = {
-                limit = 0.2,
+                limit = 5.0,
                 spawn = vec4(-7.84, -1081.35, 26.67, 121.83),
             },
             returnLocation = vec3(-44.74, -1082.58, 26.68),

--- a/config/client.lua
+++ b/config/client.lua
@@ -37,22 +37,19 @@ return {
                 offroad = 'Offroad',
             },
             testDrive = {
-                limit = 0.0, -- Time in minutes allotted for the test drive
-                spawnCoords = vec4(0.0, 0.0, 0.0, 0.0), -- Spawn location for the test drive
-                returnCoords = vec4(0.0, 0.0, 0.0, 0.0), -- Return location if test drive is finished early
+                limit = 5.0, -- Time in minutes allotted for the test drive
+                spawn = vec4(0.0, 0.0, 0.0, 0.0), -- Spawn location for the test drive
             },
             returnLocation = vec3(0.0, -1082.58, 26.68), -- Location to return vehicle only if the vehicleshop is managed
             vehicleSpawn = vec4(0.0, 0.0, 0.0, 0.0), -- Spawn location when vehicle is purchased
             showroomVehicles = {
                 [1] = {
                     coords = vec4(0.0, 0.0, 0.0, 0.0), -- where the vehicle will spawn on display
-                    defaultVehicle = '', -- Model name of default display vehicle
-                    chosenVehicle = '', -- Same as default but is dynamically changed when swapping vehicles
+                    vehicle = '', -- Model name of display vehicle. Is dynamically changed when swapping vehicles
                 },
                 [2] = {
                     coords = vec4(0.0, 0.0, 0.0, 0.0), -- where the vehicle will spawn on display
-                    defaultVehicle = '', -- Model name of default display vehicle
-                    chosenVehicle = '', -- Same as default but is dynamically changed when swapping vehicles
+                    vehicle = '', -- Model name of display vehicle. Is dynamically changed when swapping vehicles
                 },
             },
         },]]--
@@ -92,53 +89,20 @@ return {
                 cycles = 'Bicycles'
             },
             testDrive = {
-                limit = 0.5,
-                spawnCoords = vec4(-7.84, -1081.35, 26.67, 121.83),
-                returnCoords = vec4(-24.84, -1086.55, 26.57, 70.5),
+                limit = 0.2,
+                spawn = vec4(-7.84, -1081.35, 26.67, 121.83),
             },
             returnLocation = vec3(-44.74, -1082.58, 26.68),
             vehicleSpawn = vec4(-31.69, -1090.78, 26.42, 328.79),
             showroomVehicles = {
-                [1] = {
-                    coords = vec4(-45.65, -1093.66, 25.44, 69.5),
-                    defaultVehicle = 'adder',
-                    chosenVehicle = 'adder',
-                },
-                [2] = {
-                    coords = vec4(-48.27, -1101.86, 25.44, 294.5),
-                    defaultVehicle = 'schafter2',
-                    chosenVehicle = 'schafter2'
-                },
-                [3] = {
-                    coords = vec4(-39.6, -1096.01, 25.44, 66.5),
-                    defaultVehicle = 'comet2',
-                    chosenVehicle = 'comet2'
-                },
-                [4] = {
-                    coords = vec4(-51.21, -1096.77, 25.44, 254.5),
-                    defaultVehicle = 'vigero',
-                    chosenVehicle = 'vigero'
-                },
-                [5] = {
-                    coords = vec4(-40.18, -1104.13, 25.44, 338.5),
-                    defaultVehicle = 't20',
-                    chosenVehicle = 't20'
-                },
-                [6] = {
-                    coords = vec4(-43.31, -1099.02, 25.44, 52.5),
-                    defaultVehicle = 'bati',
-                    chosenVehicle = 'bati'
-                },
-                [7] = {
-                    coords = vec4(-50.66, -1093.05, 25.44, 222.5),
-                    defaultVehicle = 'bati',
-                    chosenVehicle = 'bati'
-                },
-                [8] = {
-                    coords = vec4(-44.28, -1102.47, 25.44, 298.5),
-                    defaultVehicle = 'bati',
-                    chosenVehicle = 'bati'
-                }
+                [1] = {coords = vec4(-45.65, -1093.66, 25.44, 69.5), vehicle = 'adder'},
+                [2] = {coords = vec4(-48.27, -1101.86, 25.44, 294.5), vehicle = 'schafter2'},
+                [3] = {coords = vec4(-39.6, -1096.01, 25.44, 66.5), vehicle = 'comet2'},
+                [4] = {coords = vec4(-51.21, -1096.77, 25.44, 254.5), vehicle = 'vigero'},
+                [5] = {coords = vec4(-40.18, -1104.13, 25.44, 338.5), vehicle = 't20'},
+                [6] = {coords = vec4(-43.31, -1099.02, 25.44, 52.5), vehicle = 'bati'},
+                [7] = {coords = vec4(-50.66, -1093.05, 25.44, 222.5), vehicle = 'bati'},
+                [8] = {coords = vec4(-44.28, -1102.47, 25.44, 298.5), vehicle = 'bati'}
             },
         },
 
@@ -172,43 +136,18 @@ return {
                 sports = 'Sports'
             },
             testDrive = {
-                limit = 0.5,
-                spawnCoords = vec4(-1232.81, -347.99, 37.33, 23.28),
-                returnCoords = vec4(-1261.56, -347.54, 36.83, 216.22),
+                limit = 5.0,
+                spawn = vec4(-1232.81, -347.99, 37.33, 23.28),
             },
             returnLocation = vec3(-1231.46, -349.86, 37.33),
             vehicleSpawn = vec4(-1231.46, -349.86, 37.33, 26.61),
             showroomVehicles = {
-                [1] = {
-                    coords = vec4(-1265.31, -354.44, 35.91, 205.08),
-                    defaultVehicle = 'italirsx',
-                    chosenVehicle = 'italirsx'
-                },
-                [2] = {
-                    coords = vec4(-1270.06, -358.55, 35.91, 247.08),
-                    defaultVehicle = 'italigtb',
-                    chosenVehicle = 'italigtb'
-                },
-                [3] = {
-                    coords = vec4(-1269.21, -365.03, 35.91, 297.12),
-                    defaultVehicle = 'nero',
-                    chosenVehicle = 'nero'
-                },
-                [4] = {
-                    coords = vec4(-1252.07, -364.2, 35.91, 56.44),
-                    defaultVehicle = 'bati',
-                    chosenVehicle = 'bati'
-                },
-                [5] = {
-                    coords = vec4(-1255.49, -365.91, 35.91, 55.63),
-                    defaultVehicle = 'carbonrs',
-                    chosenVehicle = 'carbonrs'
-                },
-                [6] = {
-                    coords = vec4(-1249.21, -362.97, 35.91, 53.24),
-                    defaultVehicle = 'hexer',
-                    chosenVehicle = 'hexer'
-                },
+                [1] = {coords = vec4(-1265.31, -354.44, 35.91, 205.08), vehicle = 'italirsx'},
+                [2] = {coords = vec4(-1270.06, -358.55, 35.91, 247.08), vehicle = 'italigtb'},
+                [3] = {coords = vec4(-1269.21, -365.03, 35.91, 297.12), vehicle = 'nero'},
+                [4] = {coords = vec4(-1252.07, -364.2, 35.91, 56.44), vehicle = 'bati'},
+                [5] = {coords = vec4(-1255.49, -365.91, 35.91, 55.63), vehicle = 'carbonrs'},
+                [6] = {coords = vec4(-1249.21, -362.97, 35.91, 53.24), vehicle = 'hexer'},
             }
         },
 
@@ -235,33 +174,16 @@ return {
                 boats = 'Boats'
             },
             testDrive = {
-                limit = 1.5,
-                spawnCoords = vec4(-722.23, -1351.98, 0.14, 135.33),
-                returnCoords = vec4(-733.19, -1313.45, 5.0, 226.37),
+                limit = 5.0,
+                spawn = vec4(-722.23, -1351.98, 0.14, 135.33),
             },
             returnLocation = vec3(-714.34, -1343.31, 0.0),
             vehicleSpawn = vec4(-727.87, -1353.1, -0.17, 137.09),
             showroomVehicles = {
-                [1] = {
-                    coords = vec4(-727.05, -1326.59, -0.50, 229.5),
-                    defaultVehicle = 'seashark',
-                    chosenVehicle = 'seashark'
-                },
-                [2] = {
-                    coords = vec4(-732.84, -1333.5, -0.50, 229.5),
-                    defaultVehicle = 'dinghy',
-                    chosenVehicle = 'dinghy'
-                },
-                [3] = {
-                    coords = vec4(-737.84, -1340.83, -0.50, 229.5),
-                    defaultVehicle = 'speeder',
-                    chosenVehicle = 'speeder'
-                },
-                [4] = {
-                    coords = vec4(-741.53, -1349.7, -0.50, 229.5),
-                    defaultVehicle = 'marquis',
-                    chosenVehicle = 'marquis'
-                },
+                [1] = {coords = vec4(-727.05, -1326.59, -0.50, 229.5), vehicle = 'seashark'},
+                [2] = {coords = vec4(-732.84, -1333.5, -0.50, 229.5), vehicle = 'dinghy'},
+                [3] = {coords = vec4(-737.84, -1340.83, -0.50, 229.5), vehicle = 'speeder'},
+                [4] = {coords = vec4(-741.53, -1349.7, -0.50, 229.5), vehicle = 'marquis'},
             },
         },
 
@@ -289,33 +211,16 @@ return {
                 planes = 'Planes'
             },
             testDrive = {
-                limit = 1.5,
-                spawnCoords = vec4(-1625.19, -3103.47, 13.94, 330.28),
-                returnCoords = vec4(-1639.39, -3120.24, 13.94, 148.31),
+                limit = 5.0,
+                spawn = vec4(-1625.19, -3103.47, 13.94, 330.28),
             },
             returnLocation = vec3(-1628.44, -3104.7, 13.94),
             vehicleSpawn = vec4(-1617.49, -3086.17, 13.94, 329.2),
             showroomVehicles = {
-                [1] = {
-                    coords = vec4(-1651.36, -3162.66, 12.99, 346.89),
-                    defaultVehicle = 'volatus',
-                    chosenVehicle = 'volatus'
-                },
-                [2] = {
-                    coords = vec4(-1668.53, -3152.56, 12.99, 303.22),
-                    defaultVehicle = 'luxor2',
-                    chosenVehicle = 'luxor2'
-                },
-                [3] = {
-                    coords = vec4(-1632.02, -3144.48, 12.99, 31.08),
-                    defaultVehicle = 'nimbus',
-                    chosenVehicle = 'nimbus'
-                },
-                [4] = {
-                    coords = vec4(-1663.74, -3126.32, 12.99, 275.03),
-                    defaultVehicle = 'frogger',
-                    chosenVehicle = 'frogger'
-                },
+                [1] = {coords = vec4(-1651.36, -3162.66, 12.99, 346.89), vehicle = 'volatus'},
+                [2] = {coords = vec4(-1668.53, -3152.56, 12.99, 303.22), vehicle = 'luxor2'},
+                [3] = {coords = vec4(-1632.02, -3144.48, 12.99, 31.08), vehicle = 'nimbus'},
+                [4] = {coords = vec4(-1663.74, -3126.32, 12.99, 275.03), vehicle = 'frogger'},
             },
         },
     },

--- a/server/main.lua
+++ b/server/main.lua
@@ -317,7 +317,7 @@ local function sellShowroomVehicleTransact(src, target, price, downPayment)
     player.Functions.AddMoney('bank', price * config.commissionRate)
     exports.qbx_core:Notify(src, Lang:t('success.earned_commission', {amount = CommaValue(commission)}), 'success')
 
-    exports.qbx_management:AddMoney(player.PlayerData.job.name, price)
+    exports['Renewed-Banking']:addAccountMoney(player.PlayerData.job.name, price)
     exports.qbx_core:Notify(target.PlayerData.source, Lang:t('success.purchased'), 'success')
     return true
 end


### PR DESCRIPTION
## Description

- Remove the chosenVehicle config entry and rename defaultVehicle to vehicle
- Adjust the config tables to be more readable
- Remove the two step opening process for opening the finance menu
- Rework how the information is displayed in the menu
- Add a confirmation check when paying off a vehicle in full
- Slight adjustment to the testDrive code and DrawText2D positioning
- Change default test drive time from 30 seconds to 5 minutes before despawning
- Replace the old qbx_management:AddMoney export with the proper Renewed-Banking replacement

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
