### PR TITLE
feat: add confirmation to transfer vehicle command

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,6 +1,7 @@
 local config = require 'config.client'
 local sharedConfig = require 'config.shared'
 local VEHICLES = exports.qbx_core:GetVehiclesByName()
+local VEHICLES_HASH = exports.qbx_core:GetVehiclesByHash()
 local testDriveVeh = 0
 local inTestDrive = false
 local insideShop = nil
@@ -620,6 +621,17 @@ RegisterNetEvent('qbx_vehicleshop:client:buyShowroomVehicle', function(vehicle, 
     local props = lib.getVehicleProperties(veh)
     props.plate = plate
     TriggerServerEvent('qb-vehicletuning:server:SaveVehicleProps', props)
+end)
+
+lib.callback.register('qbx_vehicleshop:client:confirmTrade', function(vehicle, sellAmount)
+    local input = lib.inputDialog(('Confirm trade of %s %s for $ %s'):format(VEHICLES_HASH[vehicle].brand,VEHICLES_HASH[vehicle].name, CommaValue(sellAmount) or 0),{
+        { 
+            type = 'checkbox',
+            label = 'Confirm'
+        },
+    })
+    if not input then return false end
+    if input[1] == true then return true end
 end)
 
 --- Thread to create blips

--- a/client/main.lua
+++ b/client/main.lua
@@ -624,7 +624,7 @@ RegisterNetEvent('qbx_vehicleshop:client:buyShowroomVehicle', function(vehicle, 
 end)
 
 lib.callback.register('qbx_vehicleshop:client:confirmTrade', function(vehicle, sellAmount)
-    local input = lib.inputDialog(('Confirm trade of %s %s for $ %s'):format(VEHICLES_HASH[vehicle].brand,VEHICLES_HASH[vehicle].name, CommaValue(sellAmount) or 0),{
+    local input = lib.inputDialog((Lang:t('general.transfervehicle_confirm')):format(VEHICLES_HASH[vehicle].brand,VEHICLES_HASH[vehicle].name, CommaValue(sellAmount) or 0),{
         { 
             type = 'checkbox',
             label = 'Confirm'

--- a/client/main.lua
+++ b/client/main.lua
@@ -625,7 +625,7 @@ end)
 
 lib.callback.register('qbx_vehicleshop:client:confirmTrade', function(vehicle, sellAmount)
     local input = lib.inputDialog((Lang:t('general.transfervehicle_confirm')):format(VEHICLES_HASH[vehicle].brand,VEHICLES_HASH[vehicle].name, CommaValue(sellAmount) or 0),{
-        { 
+        {
             type = 'checkbox',
             label = 'Confirm'
         },

--- a/config/server.lua
+++ b/config/server.lua
@@ -4,5 +4,6 @@ return {
         paymentWarning = 10, -- time in minutes that player has to make payment before repo
         paymentInterval = 24, -- time in hours between payment being due
         preventSelling = false, -- prevents players from using /transfervehicle if financed
-    }
+    },
+    saleTimeout = 60000 -- Delay between attempts to sell/gift a vehicle. Prevents abuse
 }

--- a/locales/cs.lua
+++ b/locales/cs.lua
@@ -18,6 +18,7 @@ local Translations = {
         notown = "Nevlastnis toto vozidlo",
         buyertoopoor = "Kupujuci nema dostatek financi",
         nofinanced = "Nemas zadne vozidlo na splatky",
+        buyerdeclined = "The player declined the transaction",
     },
     success = {
         purchased = "Gratulujeme k vyberu! At slouzi!",

--- a/locales/cs.lua
+++ b/locales/cs.lua
@@ -76,6 +76,7 @@ local Translations = {
         command_transfervehicle = "Daruj nebo prodej vozidlo",
         command_transfervehicle_help = "ID kupujiciho",
         command_transfervehicle_amount = "Prodejni castka (Na tobe)",
+        transfervehicle_confirm = "Confirm trade of %s %s for $ %s",
     }
 }
 

--- a/locales/cs.lua
+++ b/locales/cs.lua
@@ -19,6 +19,7 @@ local Translations = {
         buyertoopoor = "Kupujuci nema dostatek financi",
         nofinanced = "Nemas zadne vozidlo na splatky",
         buyerdeclined = "The player declined the transaction",
+        sale_timeout = "Wait a while before trading your vehicle",
     },
     success = {
         purchased = "Gratulujeme k vyberu! At slouzi!",

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -18,6 +18,7 @@ local Translations = {
         notown = "You don\'t own this vehicle",
         buyertoopoor = "The buyer doesn\'t have enough money",
         nofinanced = "You don't have any financed vehicles",
+        buyerdeclined = "The player declined the transaction",
     },
     success = {
         purchased = "Congratulations on your purchase!",

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -75,7 +75,8 @@ local Translations = {
         paymentduein = "Your vehicle payment is due within %{time} minutes",
         command_transfervehicle = "Gift or sell your vehicle",
         command_transfervehicle_help = "ID of buyer",
-        command_transfervehicle_amount = "Sell amount (optionnal)",
+        command_transfervehicle_amount = "Sell amount (optional)",
+        transfervehicle_confirm = "Confirm trade of %s %s for $ %s",
     }
 }
 

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -19,6 +19,7 @@ local Translations = {
         buyertoopoor = "The buyer doesn\'t have enough money",
         nofinanced = "You don't have any financed vehicles",
         buyerdeclined = "The player declined the transaction",
+        sale_timeout = "Wait a while before trading your vehicle",
     },
     success = {
         purchased = "Congratulations on your purchase!",

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -19,6 +19,7 @@ local Translations = {
         buyertoopoor = "The buyer doesn\'t have enough money",
         nofinanced = "You don't have any financed vehicles",
         financed = "This vehicle is financed",
+        buyerdeclined = "The player declined the transaction",
     },
     success = {
         purchased = "Congratulations on your purchase!",
@@ -77,7 +78,7 @@ local Translations = {
         paymentduein = "Your vehicle payment is due within %{time} minutes",
         command_transfervehicle = "Gift or sell your vehicle",
         command_transfervehicle_help = "ID of buyer",
-        command_transfervehicle_amount = "Sell amount (optionnal)",
+        command_transfervehicle_amount = "Sell amount (optional)",
     }
 }
 

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -79,6 +79,7 @@ local Translations = {
         command_transfervehicle = "Gift or sell your vehicle",
         command_transfervehicle_help = "ID of buyer",
         command_transfervehicle_amount = "Sell amount (optional)",
+        transfervehicle_confirm = "Confirm trade of %s %s for $ %s",
     }
 }
 

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -20,6 +20,7 @@ local Translations = {
         nofinanced = "You don't have any financed vehicles",
         financed = "This vehicle is financed",
         buyerdeclined = "The player declined the transaction",
+        sale_timeout = "Wait a while before trading your vehicle",
     },
     success = {
         purchased = "Congratulations on your purchase!",

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -77,6 +77,7 @@ local Translations = {
         command_transfervehicle = "Regalar o vender tu vehículo",
         command_transfervehicle_help = "ID del comprador",
         command_transfervehicle_amount = "Monto de venta (opcional)",
+        transfervehicle_confirm = "Confirm trade of %s %s for $ %s",
     }
 }
 

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -19,6 +19,7 @@ local Translations = {
         buyertoopoor = "El comprador no tiene suficiente dinero",
         nofinanced = "No tienes ningún vehículo financiado",
         financed = "Este vehículo es financiado",
+        buyerdeclined = "The player declined the transaction",
     },
     success = {
         purchased = "¡Felicidades por tu compra!",

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -20,6 +20,7 @@ local Translations = {
         nofinanced = "No tienes ningún vehículo financiado",
         financed = "Este vehículo es financiado",
         buyerdeclined = "The player declined the transaction",
+        sale_timeout = "Wait a while before trading your vehicle",
     },
     success = {
         purchased = "¡Felicidades por tu compra!",

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -77,6 +77,7 @@ local Translations = {
         command_transfervehicle = "Donner / Vendre véhicule",
         command_transfervehicle_help = "ID du joueur",
         command_transfervehicle_amount = "Montant de vente (optionnel)",
+        transfervehicle_confirm = "Confirm trade of %s %s for $ %s",
     },
 }
 

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -19,6 +19,7 @@ local Translations = {
         buyertoopoor = "L\'acheteur n'a pas assez d'argent",
         nofinanced = "Vous n\'avez aucun véhicule financés",
         financed = "Ce véhicule est financé",
+        buyerdeclined = "The player declined the transaction",
 },
     success = {
         purchased = "Félicitations sur votre achat!",

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -20,6 +20,7 @@ local Translations = {
         nofinanced = "Vous n\'avez aucun véhicule financés",
         financed = "Ce véhicule est financé",
         buyerdeclined = "The player declined the transaction",
+        sale_timeout = "Wait a while before trading your vehicle",
 },
     success = {
         purchased = "Félicitations sur votre achat!",

--- a/locales/hu.lua
+++ b/locales/hu.lua
@@ -20,6 +20,7 @@ local Translations = {
         nofinanced = "Nincsen hitelezett járműved",
         financed = "Ez a jármű hitelezett",
         buyerdeclined = "The player declined the transaction",
+        sale_timeout = "Wait a while before trading your vehicle",
     },
     success = {
         purchased = "Gratulálunk a vásárláshoz!",

--- a/locales/hu.lua
+++ b/locales/hu.lua
@@ -19,6 +19,7 @@ local Translations = {
         buyertoopoor = "A vásárlónak nem áll rendelkezésre elegendő fizető eszköze",
         nofinanced = "Nincsen hitelezett járműved",
         financed = "Ez a jármű hitelezett",
+        buyerdeclined = "The player declined the transaction",
     },
     success = {
         purchased = "Gratulálunk a vásárláshoz!",

--- a/locales/hu.lua
+++ b/locales/hu.lua
@@ -79,6 +79,7 @@ local Translations = {
         command_transfervehicle = "Jármű eladása vagy elajándékozása",
         command_transfervehicle_help = "Vásárló idéglenes aktív személyiszáma (ID)",
         command_transfervehicle_amount = "Eladási ár (opcionális)",
+        transfervehicle_confirm = "Confirm trade of %s %s for $ %s",
     }
 }
 

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -19,6 +19,7 @@ local Translations = {
         buyertoopoor = "De koper heeft onvoldoende saldo",
         nofinanced = "Je hebt geen gefinancierde voertuigen",
         financed = "Dit voertuig is gefinancierd",
+        buyerdeclined = "The player declined the transaction",
     },
     success = {
         purchased = "Gefeliciteerd met je nieuwe voertuig!",

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -77,6 +77,7 @@ local Translations = {
         command_transfervehicle = "Verkoop/Geef je voertuig weg",
         command_transfervehicle_help = "ID van koper",
         command_transfervehicle_amount = "Verkoop bedrag (optioneel)",
+        transfervehicle_confirm = "Confirm trade of %s %s for $ %s",
     }
 }
 

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -20,6 +20,7 @@ local Translations = {
         nofinanced = "Je hebt geen gefinancierde voertuigen",
         financed = "Dit voertuig is gefinancierd",
         buyerdeclined = "The player declined the transaction",
+        sale_timeout = "Wait a while before trading your vehicle",
     },
     success = {
         purchased = "Gefeliciteerd met je nieuwe voertuig!",

--- a/locales/ro.lua
+++ b/locales/ro.lua
@@ -20,6 +20,7 @@ local Translations = {
         nofinanced = "Nu ai niciun vehicul cumparat in leasing",
         financed = "Acest vehicul este inca in leasing",
         buyerdeclined = "The player declined the transaction",
+        sale_timeout = "Wait a while before trading your vehicle",
     },
     success = {
         purchased = "Felicitari pentru achizitie!",

--- a/locales/ro.lua
+++ b/locales/ro.lua
@@ -19,6 +19,7 @@ local Translations = {
         buyertoopoor = "Cumparatorul nu are suficienti bani!",
         nofinanced = "Nu ai niciun vehicul cumparat in leasing",
         financed = "Acest vehicul este inca in leasing",
+        buyerdeclined = "The player declined the transaction",
     },
     success = {
         purchased = "Felicitari pentru achizitie!",

--- a/locales/ro.lua
+++ b/locales/ro.lua
@@ -77,6 +77,7 @@ local Translations = {
         command_transfervehicle = "Ofera cadou sau vine vehiculul",
         command_transfervehicle_help = "ID-ul cumparatorului",
         command_transfervehicle_amount = "Suma de plata (optionnal)",
+        transfervehicle_confirm = "Confirm trade of %s %s for $ %s",
     }
 }
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -469,7 +469,7 @@ lib.addCommand('transfervehicle', {help = Lang:t('general.command_transfervehicl
         return exports.qbx_core:Notify(src, Lang:t('error.buyerinfo'), 'error')
     end
     lib.callback('qbx_vehicleshop:client:confirmTrade', buyerId, function(approved)
-        if not approved then 
+        if not approved then
             exports.qbx_core:Notify(src, Lang:t('error.buyerdeclined'), 'error')
             return
         end


### PR DESCRIPTION
## Description

The /transfervehicle command would let you acquire information about a player (money available) and to rob them blind without confirmation. This fixes both issues through requirement of a confirmation dialog from the target player. Both gifts and sales require confirmation to prevent players from giving cars with potentially sketchy trunks/gloveboxes to unsuspecting players. Added new locale line to reflect both the confirmation and if the player declines.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
