### PR TITLE
fix(client): issue with categories loading

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -199,7 +199,9 @@ local function openVehCatsMenu(category)
 
     for k, v in pairs(VEHICLES) do
         if VEHICLES[k].category == category then
-            if type(config.vehicles[k].shop) == 'table' then
+            if config.vehicles[k] == nil then
+                lib.print.debug('Vehicle not found in config.vehicles. Skipping: '..k)
+            elseif type(config.vehicles[k].shop) == 'table' then
                 for _, shop in pairs(config.vehicles[k].shop) do
                     if shop == insideShop then
                         vehMenu[#vehMenu + 1] = {


### PR DESCRIPTION
## Description

Fixes an issue where when a player updated to the new qbx_core with the updated vehicles.lua, categories errored out since not all vehicle were in the config.vehicles. The if statement allows the categories to open without those vehicles. It will print a debug message if ox:printlevel is set to debug.

_Fixes https://github.com/Qbox-project/qbx_core/issues/291_

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
