### PR TITLE
feat: vehicle categories shown correctly as the title

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -204,7 +204,7 @@ local function openVehCatsMenu(category)
                     if shop == insideShop then
                         vehMenu[#vehMenu + 1] = {
                             title = v.brand..' '..v.name,
-                            description = Lang:t('menus.veh_price')..v.price,
+                            description = Lang:t('menus.veh_price')..lib.math.groupdigits(v.price),
                             serverEvent = 'qbx_vehicleshop:server:swapVehicle',
                             args = {
                                 toVehicle = v.model,
@@ -217,7 +217,7 @@ local function openVehCatsMenu(category)
             elseif config.vehicles[k].shop == insideShop then
                 vehMenu[#vehMenu + 1] = {
                     title = v.brand..' '..v.name,
-                    description = Lang:t('menus.veh_price')..v.price,
+                    description = Lang:t('menus.veh_price')..lib.math.groupdigits(v.price),
                     serverEvent = 'qbx_vehicleshop:server:swapVehicle',
                     args = {
                         toVehicle = v.model,

--- a/client/main.lua
+++ b/client/main.lua
@@ -231,7 +231,7 @@ local function openVehCatsMenu(category)
 
     lib.registerContext({
         id = 'openVehCats',
-        title = Lang:t('menus.categories_header'),
+        title = config.shops[insideShop].categories[category],
         menu = 'vehicleCategories',
         options = vehMenu
     })


### PR DESCRIPTION
## Description

This pull request makes it so the Vehicle Categories are shown correctly as the Menu Title, as shown in the photo here.
![image](https://github.com/Qbox-project/qbx_vehicleshop/assets/101289888/1dcb1043-bcc0-40d9-bf14-9140ec062205)

This pull requests also makes the Vehicle Price to be grouped using lib.math.groupdigits
![image](https://github.com/Qbox-project/qbx_vehicleshop/assets/101289888/7d785b18-f78b-4afa-9a3a-d10e0f822098)


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
