### PR TITLE
Swap vehicle model check.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -604,7 +604,7 @@ RegisterNetEvent('qbx_vehicleshop:client:swapVehicle', function(data)
     if not closestVehicle then return end
     
     if not IsModelInCdimage(data.toVehicle) then
-        print(('Failed to find model for "%s". Vehicle might not be streamed?'):format(data.toVehicle))
+        lib.print.error(('Failed to find model for "%s". Vehicle might not be streamed?'):format(data.toVehicle))
         return 
     end    
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -602,6 +602,11 @@ RegisterNetEvent('qbx_vehicleshop:client:swapVehicle', function(data)
 
     local closestVehicle = lib.getClosestVehicle(dataClosestVehicle.coords.xyz, 5, false)
     if not closestVehicle then return end
+    
+    if not IsModelInCdimage(data.toVehicle) then
+        print(('Failed to find model for "%s". Vehicle might not be streamed?'):format(data.toVehicle))
+        return 
+    end    
 
     DeleteEntity(closestVehicle)
     while DoesEntityExist(closestVehicle) do


### PR DESCRIPTION
This adds a check to make sure the model you are trying to swap to exists/streamed before making the swap. Without this, if you have a "vehicle364" (which isn't streamed) as the example model you are trying to swap to, it will delete the previous vehicle and attempt to load the new one and fail, making it so you can not interact with the vehicle in that particular spot unless you relog.


- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
