### PR TITLE
fix: swap the vehicle you target

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -223,15 +223,15 @@ local function openVehCatsMenu(category, targetVehicle)
 end
 
 --- Opens a menu with list of vehicle categories
----@param targetVehicle number
-local function openVehicleCategoryMenu(targetVehicle)
+---@param args table<string, any>
+local function openVehicleCategoryMenu(args)
     local categoryMenu = {}
     for k, v in pairs(config.shops[insideShop].categories) do
         categoryMenu[#categoryMenu + 1] = {
             title = v,
             arrow = true,
             onSelect = function()
-                openVehCatsMenu(k, targetVehicle)
+                openVehCatsMenu(k, args.targetVehicle)
             end
         }
     end

--- a/config/client.lua
+++ b/config/client.lua
@@ -163,7 +163,7 @@ return {
                     vec3(-716.94, -1326.88, 0)
                 },
                 size = vec3(8, 8, 6),
-                targetDistance = 5,
+                targetDistance = 10,
             },
             blip = {
                 label = 'Marina Shop',


### PR DESCRIPTION
## Description

Let's stop always using the 'closest' vehicle or the 'closest' player,
there's a target system, you can know precisely what the player wanted to interact with instead of guessing..
At least for cases like this where we can make it work even for the people that don't use ox_target.

Should work fine for the no-target people, needs testing to be sure tho

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.