### PR TITLE
fix: target not checking for job

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -431,6 +431,7 @@ local function createVehicleTarget(shopName, entity, targetVehicle)
             icon = 'fas fa-car',
             label = locale('general.vehinteraction'),
             distance = shop.zone.targetDistance,
+            groups = shop.job,
             onSelect = function()
                 openVehicleSellMenu(targetVehicle)
             end


### PR DESCRIPTION
## Description
The target option wasn't checking for the player's job.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
