### PR TITLE
feat: vehicleId statebag on vehicle spawn

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "cache",
         "QBX",
         "locale",
-        "qbx"
+        "qbx",
+        "MySQL"
     ]
 }

--- a/client/main.lua
+++ b/client/main.lua
@@ -632,9 +632,9 @@ end)
 --- Buys the selected vehicle
 ---@param vehicle number
 ---@param plate string
-RegisterNetEvent('qbx_vehicleshop:client:buyShowroomVehicle', function(vehicle, plate)
+RegisterNetEvent('qbx_vehicleshop:client:buyShowroomVehicle', function(vehicle, plate, vehicleId)
     local tempShop = insideShop -- temp hacky way of setting the shop because it changes after the callback has returned since you are outside the zone
-    local netId = lib.callback.await('qbx_vehicleshop:server:spawnVehicle', false, vehicle, config.shops[tempShop].vehicleSpawn, plate)
+    local netId = lib.callback.await('qbx_vehicleshop:server:spawnVehicle', false, vehicle, config.shops[tempShop].vehicleSpawn, plate, vehicleId)
     local veh = NetToVeh(netId)
     local props = lib.getVehicleProperties(veh)
     props.plate = plate

--- a/server/main.lua
+++ b/server/main.lua
@@ -285,7 +285,7 @@ RegisterNetEvent('qbx_vehicleshop:server:financeVehicle', function(downPayment, 
     local cid = player.PlayerData.citizenid
     local timer = (config.finance.paymentInterval * 60)
 
-    InsertVehicleEntityWithFinance({
+    local vehicleId = InsertVehicleEntityWithFinance({
         insertVehicleEntityRequest = {
             citizenId = cid,
             model = vehicle,
@@ -299,7 +299,7 @@ RegisterNetEvent('qbx_vehicleshop:server:financeVehicle', function(downPayment, 
         }
     })
     exports.qbx_core:Notify(src, locale('success.purchased'), 'success')
-    TriggerClientEvent('qbx_vehicleshop:client:buyShowroomVehicle', src, vehicle, plate)
+    TriggerClientEvent('qbx_vehicleshop:client:buyShowroomVehicle', src, vehicle, plate, vehicleId)
     player.Functions.RemoveMoney(currencyType, downPayment, 'vehicle-bought-in-showroom')
 end)
 
@@ -391,7 +391,7 @@ RegisterNetEvent('qbx_vehicleshop:server:sellfinanceVehicle', function(downPayme
 
     if not sellShowroomVehicleTransact(src, target, vehiclePrice, downPayment) then return end
 
-    InsertVehicleEntityWithFinance({
+    local vehicleId = InsertVehicleEntityWithFinance({
         insertVehicleEntityRequest = {
             citizenId = cid,
             model = vehicle,
@@ -405,7 +405,7 @@ RegisterNetEvent('qbx_vehicleshop:server:sellfinanceVehicle', function(downPayme
         }
     })
 
-    TriggerClientEvent('qbx_vehicleshop:client:buyShowroomVehicle', target.PlayerData.source, vehicle, plate)
+    TriggerClientEvent('qbx_vehicleshop:client:buyShowroomVehicle', target.PlayerData.source, vehicle, plate, vehicleId)
 end)
 
 -- Check if payment is due

--- a/server/main.lua
+++ b/server/main.lua
@@ -79,12 +79,12 @@ local function calculateNewFinance(paymentAmount, vehData)
     return qbx.math.round(newBalance), qbx.math.round(newPayment), newPaymentsLeft
 end
 
-local function generatePlate()
-    local plate
-    repeat
-        plate = qbx.generateRandomPlate('11AAA111')
-    until not DoesVehicleEntityExist(plate)
-    return plate:upper()
+local function generateUniquePlate()
+    while true do
+        local plate = qbx.generateRandomPlate('11AAA111')
+        if not DoesVehicleEntityExist(plate) then return plate end
+        Wait(0)
+    end
 end
 
 -- Callbacks
@@ -106,10 +106,12 @@ lib.callback.register('qbx_vehicleshop:server:GetVehiclesByName', function(sourc
     end
 end)
 
-lib.callback.register('qbx_vehicleshop:server:spawnVehicle', function(source, model, coords, plate)
+lib.callback.register('qbx_vehicleshop:server:spawnVehicle', function(source, model, coords, plate, vehicleId)
     local netId, veh = qbx.spawnVehicle({model = model, spawnSource = coords, warp = GetPlayerPed(source)})
     if not netId or netId == 0 then return end
     if not veh or veh == 0 then return end
+
+    if vehicleId then Entity(veh).state:set('vehicleid', vehicleId, false) end
 
     SetVehicleNumberPlateText(veh, plate)
     TriggerClientEvent('vehiclekeys:client:SetOwner', source, plate)
@@ -239,18 +241,17 @@ RegisterNetEvent('qbx_vehicleshop:server:buyShowroomVehicle', function(vehicle)
     local vehiclePrice = coreVehicles[vehicle].price
     local currencyType = findChargeableCurrencyType(vehiclePrice, player.PlayerData.money.cash, player.PlayerData.money.bank)
     if not currencyType then
-        exports.qbx_core:Notify(src, locale('error.notenoughmoney'), 'error')
-        return
+        return exports.qbx_core:Notify(src, locale('error.notenoughmoney'), 'error')
     end
 
-    local plate = generatePlate()
-    exports.qbx_vehicles:CreateVehicleEntity({
+    local plate = generateUniquePlate()
+    local vehicleId = exports.qbx_vehicles:CreateVehicleEntity({
         citizenId = player.PlayerData.citizenid,
         model = vehicle,
         plate = plate,
     })
     exports.qbx_core:Notify(src, locale('success.purchased'), 'success')
-    TriggerClientEvent('qbx_vehicleshop:client:buyShowroomVehicle', src, vehicle, plate)
+    TriggerClientEvent('qbx_vehicleshop:client:buyShowroomVehicle', src, vehicle, plate, vehicleId)
     player.Functions.RemoveMoney(currencyType, vehiclePrice, 'vehicle-bought-in-showroom')
 end)
 
@@ -279,7 +280,7 @@ RegisterNetEvent('qbx_vehicleshop:server:financeVehicle', function(downPayment, 
         return exports.qbx_core:Notify(src, locale('error.notenoughmoney'), 'error')
     end
 
-    local plate = generatePlate()
+    local plate = generateUniquePlate()
     local balance, vehPaymentAmount = calculateFinance(vehiclePrice, downPayment, paymentAmount)
     local cid = player.PlayerData.citizenid
     local timer = (config.finance.paymentInterval * 60)
@@ -342,17 +343,17 @@ RegisterNetEvent('qbx_vehicleshop:server:sellShowroomVehicle', function(data, pl
     local vehicle = data
     local vehiclePrice = coreVehicles[vehicle].price
     local cid = target.PlayerData.citizenid
-    local plate = generatePlate()
+    local plate = generateUniquePlate()
 
     if not sellShowroomVehicleTransact(src, target, vehiclePrice, vehiclePrice) then return end
 
-    exports.qbx_vehicles:CreateVehicleEntity({
+    local vehicleId = exports.qbx_vehicles:CreateVehicleEntity({
         citizenId = cid,
         model = vehicle,
         plate = plate
     })
 
-    TriggerClientEvent('qbx_vehicleshop:client:buyShowroomVehicle', target.PlayerData.source, vehicle, plate)
+    TriggerClientEvent('qbx_vehicleshop:client:buyShowroomVehicle', target.PlayerData.source, vehicle, plate, vehicleId)
 end)
 
 -- Finance vehicle to customer
@@ -385,7 +386,7 @@ RegisterNetEvent('qbx_vehicleshop:server:sellfinanceVehicle', function(downPayme
 
     local cid = target.PlayerData.citizenid
     local timer = (config.finance.paymentInterval * 60)
-    local plate = generatePlate()
+    local plate = generateUniquePlate()
     local balance, vehPaymentAmount = calculateFinance(vehiclePrice, downPayment, paymentAmount)
 
     if not sellShowroomVehicleTransact(src, target, vehiclePrice, downPayment) then return end

--- a/server/main.lua
+++ b/server/main.lua
@@ -82,7 +82,7 @@ end
 local function generateUniquePlate()
     while true do
         local plate = qbx.generateRandomPlate('11AAA111')
-        if not DoesVehicleEntityExist(plate) then return plate end
+        if not DoesVehicleEntityExist(plate) and not exports.qbx_vehicles:DoesEntityPlateExist(plate) then return plate end
         Wait(0)
     end
 end

--- a/server/storage.lua
+++ b/server/storage.lua
@@ -27,6 +27,8 @@ function InsertVehicleEntityWithFinance(request)
         request.vehicleFinance.paymentsLeft,
         request.vehicleFinance.timer
     })
+
+    return vehicleId
 end
 
 ---@alias VehicleEntity table


### PR DESCRIPTION
## Description

Fixes https://github.com/Qbox-project/qbx_garages/issues/55

The main change is the addition of vehicleId to the statebag of freshly purchased vehicles.
The generatePlate function has also been renamed, to a more descriptive name.
> There is still a risk of generating a plate that is in the database. A SQL procedure for creating a vehicle could solve the problem. 

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
