### PR TITLE
feat: delete vehicle_financing entry when car is paid off

### DIFF
--- a/server/storage.lua
+++ b/server/storage.lua
@@ -70,13 +70,19 @@ end
 ---@param vehicleFinance VehicleFinanceServer
 ---@param plate string
 function UpdateVehicleFinance(vehicleFinance, plate)
-    MySQL.update('UPDATE vehicle_financing AS vf INNER JOIN player_vehicles AS pv ON vf.vehicleId = pv.id SET vf.balance = ?, vf.paymentamount = ?, vf.paymentsleft = ?, vf.financetime = ? WHERE pv.plate = ?', {
-        vehicleFinance.balance,
-        vehicleFinance.payment,
-        vehicleFinance.paymentsLeft,
-        vehicleFinance.timer,
-        plate
-    })
+    if vehicleFinance.balance == 0 then
+        MySQL.query('DELETE FROM vehicle_financing WHERE plate = ?', {
+            plate
+        })
+    else
+        MySQL.update('UPDATE vehicle_financing AS vf INNER JOIN player_vehicles AS pv ON vf.vehicleId = pv.id SET vf.balance = ?, vf.paymentamount = ?, vf.paymentsleft = ?, vf.financetime = ? WHERE pv.plate = ?', {
+            vehicleFinance.balance,
+            vehicleFinance.payment,
+            vehicleFinance.paymentsLeft,
+            vehicleFinance.timer,
+            plate
+        })
+    end
 end
 
 ---@param citizenId string


### PR DESCRIPTION
If a car isn't financed in the first place it will not have an entry in the vehicle_financing table, so it makes sense to use no entry as the state of a paid off vehicle.