### PR TITLE
fix(server/main): unique generate plate pattern

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -81,7 +81,7 @@ end
 
 local function generateUniquePlate()
     while true do
-        local plate = qbx.generateRandomPlate('11AAA111')
+        local plate = qbx.generateRandomPlate('111AA11A')
         if not DoesVehicleEntityExist(plate) and not exports.qbx_vehicles:DoesPlayerVehiclePlateExist(plate) then return plate end
         Wait(0)
     end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Generating plates for vehicles that match the native gta plates can lead to collisions. This fixes that

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
