### PR TITLE
fix(server/main): typo

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -121,7 +121,7 @@ end)
 ---@param shop string? Shop name to check if vehicle is allowed in that shop
 ---@return boolean
 local function checkVehicleList(vehicle, shop)
-    for i = 1, allowedVehiclesCount do
+    for i = 1, #allowedVehiclesCount do
         local allowedVeh = allowedVehicles[i]
         if allowedVeh.model == vehicle then
             if shop and allowedVeh.shopType == shop then


### PR DESCRIPTION
## Description

Missing `#` which causes an error to be thrown when interacting with vehicles

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
