### PR TITLE
fix: modules invalidly returning more than one value

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,6 +1,6 @@
 local config = require 'config.client'
 local sharedConfig = require 'config.shared'
-local vehiclesMenu, vehiclesMenuCount = require 'client.vehicles'
+local vehiclesMenu = require 'client.vehicles'
 local VEHICLES = exports.qbx_core:GetVehiclesByName()
 local VEHICLES_HASH = exports.qbx_core:GetVehiclesByHash()
 local testDriveVeh = 0
@@ -185,8 +185,8 @@ end
 local function openVehCatsMenu(category, targetVehicle)
 
     local categoryMenu = {}
-    for i = 1, vehiclesMenuCount do
-        local vehicle = vehiclesMenu[i]
+    for i = 1, vehiclesMenu.count do
+        local vehicle = vehiclesMenu.vehicles[i]
         if vehicle.category == category and vehicle.shopType == insideShop then
             vehicle.args.closestShop = insideShop
             vehicle.args.targetVehicle = targetVehicle

--- a/client/vehicles.lua
+++ b/client/vehicles.lua
@@ -50,4 +50,7 @@ table.sort(vehicles, function(a, b)
     return aName < bName
 end)
 
-return vehicles, count
+return {
+    vehicles = vehicles,
+    count = count,
+}

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,7 +5,7 @@ assert(lib.checkDependency('qbx_vehicles', '1.4.1'), 'qbx_vehicles v1.4.1 or hig
 local config = require 'config.server'
 local sharedConfig = require 'config.shared'
 local finance = require 'server.finance'
-local allowedVehicles, allowedVehiclesCount = require 'server.vehicles'
+local allowedVehicles = require 'server.vehicles'
 local financeTimer = {}
 local coreVehicles = exports.qbx_core:GetVehiclesByName()
 local shopZones = {}
@@ -121,8 +121,8 @@ end)
 ---@param shop string? Shop name to check if vehicle is allowed in that shop
 ---@return boolean
 local function checkVehicleList(vehicle, shop)
-    for i = 1, allowedVehiclesCount do
-        local allowedVeh = allowedVehicles[i]
+    for i = 1, allowedVehicles.count do
+        local allowedVeh = allowedVehicles.vehicles[i]
         if allowedVeh.model == vehicle then
             if shop and allowedVeh.shopType == shop then
                 return true

--- a/server/vehicles.lua
+++ b/server/vehicles.lua
@@ -36,4 +36,7 @@ for k, vehicle in pairs(VEHICLES) do
     end
 end
 
-return vehicles, count
+return {
+    vehicles = vehicles,
+    count = count,
+}


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Modules cannot return more than one value, since it won't be caught. Instead, wrap it in a table.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
