### PR TITLE
refactor(testdrive): provice choice for ending test drive behavior

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -294,6 +294,11 @@ local function startTestDrive(vehModel)
     TriggerServerEvent('qbx_vehicleshop:server:customTestDrive', vehModel, playerId)
 end
 
+lib.onCache('vehicle', function(value)
+    if value or not LocalPlayer.state.inTestDrive then return end
+    LocalPlayer.state:set('inTestDrive', nil, true)
+end)
+
 ---@param vehModel string
 local function sellVehicle(vehModel)
     local playerId = getPlayerIdInput(vehModel)

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -222,50 +222,8 @@ return {
         }
     },
 
+    ---@type table<string, Dealership>
     shops = {
-        --[[shop = { -- Needs to be unique
-            type = '', -- If 'free-use', no player-to-player interaction required to purchase. If 'managed', caresalesman required for purchase
-            job = '', -- If shop is 'free-use', remove this option. If shop is 'managed', put required job
-            zone = {
-                shape = { -- Polygon that surrounds the shop
-                    vec3(0.0, 0.0, 0.0),
-                    vec3(0.0, 0.0, 0.0),
-                    vec3(0.0, 0.0, 0.0),
-                    vec3(0.0, 0.0, 0.0),
-                },
-                size = vec3(0.0, 0.0, 0.0), -- Size of the vehicles zones (x, y, z)
-                targetDistance = 1, -- Defines targeting distance. Only works if useTarget is enabled
-            },
-            blip = {
-                label = '', -- Blip label
-                coords = vec3(0.0, 0.0, 0.0), -- Blip coordinates
-                show = true, -- Enables/disables the blip being shown
-                sprite = 0, -- Blip sprite
-                color = 0, -- Blip color
-            },
-            categories = { -- Categories available to browse
-                sedans = 'Sedans',
-                coupes = 'Coupes',
-                suvs = 'SUVs',
-                offroad = 'Offroad',
-            },
-            testDrive = {
-                limit = 5.0, -- Time in minutes allotted for the test drive
-                spawn = vec4(0.0, 0.0, 0.0, 0.0), -- Spawn location for the test drive
-            },
-            returnLocation = vec3(0.0, -1082.58, 26.68), -- Location to return vehicle only if the vehicleshop is managed
-            vehicleSpawn = vec4(0.0, 0.0, 0.0, 0.0), -- Spawn location when vehicle is purchased
-            showroomVehicles = {
-                [1] = {
-                    coords = vec4(0.0, 0.0, 0.0, 0.0), -- where the vehicle will spawn on display
-                    vehicle = '', -- Model name of display vehicle. Is dynamically changed when swapping vehicles
-                },
-                [2] = {
-                    coords = vec4(0.0, 0.0, 0.0, 0.0), -- where the vehicle will spawn on display
-                    vehicle = '', -- Model name of display vehicle. Is dynamically changed when swapping vehicles
-                },
-            },
-        },]]--
         pdm = {
             type = 'free-use',
             zone = {
@@ -304,6 +262,7 @@ return {
             testDrive = {
                 limit = 5.0,
                 spawn = vec4(-7.84, -1081.35, 26.67, 121.83),
+                endBehavior = 'return'
             },
             returnLocation = vec3(-44.74, -1082.58, 26.68),
             vehicleSpawn = vec4(-31.69, -1090.78, 26.42, 328.79),
@@ -351,6 +310,7 @@ return {
             testDrive = {
                 limit = 5.0,
                 spawn = vec4(-1232.81, -347.99, 37.33, 23.28),
+                endBehavior = 'return'
             },
             returnLocation = vec3(-1231.46, -349.86, 37.33),
             vehicleSpawn = vec4(-1231.46, -349.86, 37.33, 26.61),
@@ -389,6 +349,7 @@ return {
             testDrive = {
                 limit = 5.0,
                 spawn = vec4(-722.23, -1351.98, 0.14, 135.33),
+                endBehavior = 'return'
             },
             returnLocation = vec3(-714.34, -1343.31, 0.0),
             vehicleSpawn = vec4(-727.87, -1353.1, -0.17, 137.09),
@@ -426,6 +387,7 @@ return {
             testDrive = {
                 limit = 5.0,
                 spawn = vec4(-1625.19, -3103.47, 13.94, 330.28),
+                endBehavior = 'return'
             },
             returnLocation = vec3(-1628.44, -3104.7, 13.94),
             vehicleSpawn = vec4(-1617.49, -3086.17, 13.94, 329.2),

--- a/types.lua
+++ b/types.lua
@@ -34,3 +34,35 @@
 ---@field paymentamount number
 ---@field paymentsleft integer
 ---@field financetime number
+
+---@class DealershipZone -- Zone definition for dealership
+---@field shape vector3[] -- poly zone points. All Z values should be the same
+---@field size vector3 -- Size of the showroom zones
+---@field targetDistance number -- Distance for targets inside zone
+
+---@class DealershipBlip -- Blip definition for dealership
+---@field label string -- Blip label
+---@field coords vector3 -- Blip coordinates
+---@field show boolean -- Whether to show the blip
+---@field sprite integer -- Blip sprite
+---@field color integer -- Blip color
+
+---@class DealershipVehicle -- Showroom spot definition
+---@field coords vector4 -- coordinates to spawn showroom vehicle
+---@field vehicle string -- vehicle model
+
+---@class TestDriveConfig -- Test drive configuration
+---@field limit number -- Time for test drive in minutes
+---@field spawn vector4 -- Location to spawn test drive vehicle
+---@field endBehavior 'return'|'destroy'|'none' -- 'none' will not do anything, 'return' will return the player to the dealership and destroy the vehicle, 'destroy' will destroy the vehicle and leave player at current position
+
+---@class Dealership -- Dealership configuration
+---@field type 'free-use'|'managed' -- 'free-use' allows players to purchase vehicles without any restrictions, 'managed' requires a job to purchase vehicles
+---@field job string? -- Only required if type is 'managed'
+---@field zone DealershipZone
+---@field blip DealershipBlip
+---@field categories table<string, string> -- Key is the category name, value is the category label
+---@field showroomVehicles DealershipVehicle[]
+---@field testDrive TestDriveConfig
+---@field returnLocation vector3 -- Location to return the vehicle to for test drives
+---@field vehicleSpawn vector4 -- Location to spawn purchased vehicles


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Allows user to define the test drive behavior per dealership and moves dealership configuration descriptions to types.lua

Options for test drive include nothing, return which destroys the vehicle and brings the player back and destroy which leaves the player where they are and destroys the vehicle

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
