### PR TITLE
Add exception case to addSocietyFunds

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -20,7 +20,12 @@ return {
     ---@param amount number Amount to add
     ---@return boolean
     addSocietyFunds = function(society, amount) -- function to add funds to society
-        return exports['Renewed-Banking']:addAccountMoney(society, amount)
+        if GetResourceState('Renewed-Banking'):find('started') then
+            return exports['Renewed-Banking']:addAccountMoney(society, amount)
+        else
+            lib.print.error(('Renewed-Banking is needed for Society Funds and it\'s currently %s'):format(GetResourceState('Renewed-Banking')))
+            return false
+        end
     end,
 
     ---@param player any QBX Player object


### PR DESCRIPTION
## Description

If Renewed bank is missing, it would remove the players money, give the commision to the seller, but wouldn't give the car to the player, because it errors out in the addSocietyFunds.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
