### PR TITLE
feat(server): multiple vehicle spawns and spawn checking

### DIFF
--- a/config/shared.lua
+++ b/config/shared.lua
@@ -261,11 +261,17 @@ return {
             },
             testDrive = {
                 limit = 5.0,
-                spawn = vec4(-7.84, -1081.35, 26.67, 121.83),
                 endBehavior = 'return'
             },
             returnLocation = vec3(-32.77, -1095.75, 26.42),
-            vehicleSpawn = vec4(-31.69, -1090.78, 26.42, 328.79),
+            vehicleSpawns = {
+                vec4(-61.35, -1110.31, 25.86, 71.01),
+                vec4(-59.61, -1104.74, 25.85, 70.13),
+                vec4(-52.96, -1113.49, 25.87, 71.53),
+                vec4(-52.34, -1107.93, 25.87, 71.63),
+                vec4(-44.27, -1116.36, 25.87, 71.7),
+                vec4(-41.75, -1111.49, 25.87, 71.5),
+            },
             showroomVehicles = {
                 [1] = {coords = vec4(-45.65, -1093.66, 25.44, 69.5), vehicle = 'asbo'},
                 [2] = {coords = vec4(-48.27, -1101.86, 25.44, 294.5), vehicle = 'schafter2'},
@@ -309,11 +315,12 @@ return {
             },
             testDrive = {
                 limit = 5.0,
-                spawn = vec4(-1232.81, -347.99, 37.33, 23.28),
                 endBehavior = 'return'
             },
             returnLocation = vec3(-1231.46, -349.86, 37.33),
-            vehicleSpawn = vec4(-1231.46, -349.86, 37.33, 26.61),
+            vehicleSpawns = {
+                vec4(-1231.46, -349.86, 37.33, 26.61),
+            },
             showroomVehicles = {
                 [1] = {coords = vec4(-1265.31, -354.44, 35.91, 205.08), vehicle = 'italirsx'},
                 [2] = {coords = vec4(-1270.06, -358.55, 35.91, 247.08), vehicle = 'italigtb'},
@@ -348,11 +355,12 @@ return {
             },
             testDrive = {
                 limit = 5.0,
-                spawn = vec4(-722.23, -1351.98, 0.14, 135.33),
                 endBehavior = 'return'
             },
             returnLocation = vec3(-714.34, -1343.31, 0.0),
-            vehicleSpawn = vec4(-727.87, -1353.1, -0.17, 137.09),
+            vehicleSpawns = {
+                vec4(-727.87, -1353.1, -0.17, 137.09),
+            },
             showroomVehicles = {
                 [1] = {coords = vec4(-727.05, -1326.59, -0.50, 229.5), vehicle = 'seashark'},
                 [2] = {coords = vec4(-732.84, -1333.5, -0.50, 229.5), vehicle = 'dinghy'},
@@ -386,11 +394,12 @@ return {
             },
             testDrive = {
                 limit = 5.0,
-                spawn = vec4(-1625.19, -3103.47, 13.94, 330.28),
                 endBehavior = 'return'
             },
             returnLocation = vec3(-1628.44, -3104.7, 13.94),
-            vehicleSpawn = vec4(-1617.49, -3086.17, 13.94, 329.2),
+            vehicleSpawns = {
+                vec4(-1617.49, -3086.17, 13.94, 329.2),
+            },
             showroomVehicles = {
                 [1] = {coords = vec4(-1651.36, -3162.66, 12.99, 346.89), vehicle = 'volatus'},
                 [2] = {coords = vec4(-1668.53, -3152.56, 12.99, 303.22), vehicle = 'luxor2'},

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -22,7 +22,8 @@
         "buyerdeclined": "The player declined the transaction",
         "selftransfer": "You can't transfer to yourself",
         "sale_timeout": "Wait a while before trading your vehicle",
-        "notallowed": "You are not allowed to purchase this vehicle model"
+        "notallowed": "You are not allowed to purchase this vehicle model",
+        "no_clear_spawn": "No spawn area found for vehicle."
     },
     "success": {
         "purchased": "Gratulujeme k vyberu! At slouzi!",

--- a/locales/de.json
+++ b/locales/de.json
@@ -22,7 +22,8 @@
       "buyerdeclined": "Der Spieler hat die Transaktion abgelehnt",
       "selftransfer": "Du kannst das Fahrzeug nicht an dich selbst übertragen",
       "sale_timeout": "Warte eine Weile, bevor du dein Fahrzeug handelst",
-      "notallowed": "Du darfst dieses Fahrzeugmodell nicht kaufen"
+      "notallowed": "Du darfst dieses Fahrzeugmodell nicht kaufen",
+      "no_clear_spawn": "No spawn area found for vehicle."
     },
     "success": {
       "purchased": "Herzlichen Glückwunsch zu deinem Kauf!",

--- a/locales/en.json
+++ b/locales/en.json
@@ -23,7 +23,8 @@
         "buyerdeclined": "The player declined the transaction",
         "selftransfer": "You can't transfer to yourself",
         "sale_timeout": "Wait a while before trading your vehicle",
-        "notallowed": "You are not allowed to purchase this vehicle model"
+        "notallowed": "You are not allowed to purchase this vehicle model",
+        "no_clear_spawn": "No spawn area found for vehicle."
     },
     "success": {
         "purchased": "Congratulations on your purchase!",

--- a/locales/es.json
+++ b/locales/es.json
@@ -23,7 +23,8 @@
         "buyerdeclined": "The player declined the transaction",
         "selftransfer": "You can't transfer to yourself",
         "sale_timeout": "Wait a while before trading your vehicle",
-        "notallowed": "You are not allowed to purchase this vehicle model"
+        "notallowed": "You are not allowed to purchase this vehicle model",
+        "no_clear_spawn": "No spawn area found for vehicle."
     },
     "success": {
         "purchased": "¡Felicidades por tu compra!",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -23,7 +23,8 @@
         "buyerdeclined": "The player declined the transaction",
         "selftransfer": "Vous ne pouvez pas transférer à vous-même",
         "sale_timeout": "Wait a while before trading your vehicle",
-        "notallowed": "You are not allowed to purchase this vehicle model"
+        "notallowed": "You are not allowed to purchase this vehicle model",
+        "no_clear_spawn": "No spawn area found for vehicle."
     },
     "success": {
         "purchased": "Félicitations sur votre achat!",

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -23,7 +23,8 @@
         "buyerdeclined": "The player declined the transaction",
         "selftransfer": "You can't transfer to yourself",
         "sale_timeout": "Wait a while before trading your vehicle",
-        "notallowed": "You are not allowed to purchase this vehicle model"
+        "notallowed": "You are not allowed to purchase this vehicle model",
+        "no_clear_spawn": "No spawn area found for vehicle."
     },
     "success": {
         "purchased": "Gratulálunk a vásárláshoz!",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -23,7 +23,8 @@
         "buyerdeclined": "The player declined the transaction",
         "selftransfer": "You can't transfer to yourself",
         "sale_timeout": "Wait a while before trading your vehicle",
-        "notallowed": "You are not allowed to purchase this vehicle model"
+        "notallowed": "You are not allowed to purchase this vehicle model",
+        "no_clear_spawn": "No spawn area found for vehicle."
     },
     "success": {
         "purchased": "Gefeliciteerd met je nieuwe voertuig!",

--- a/locales/pt-br.json
+++ b/locales/pt-br.json
@@ -23,7 +23,8 @@
         "buyerdeclined": "O jogador recusou a transação",
         "selftransfer": "Você não pode transferir para si mesmo",
         "sale_timeout": "Espere um pouco antes de negociar seu veículo",
-        "notallowed": "Você não tem permissão para comprar este modelo de veículo"
+        "notallowed": "Você não tem permissão para comprar este modelo de veículo",
+        "no_clear_spawn": "No spawn area found for vehicle."
     },
     "success": {
         "purchased": "Parabéns pela compra!",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -23,7 +23,8 @@
         "buyerdeclined": "O jogador recusou a transação",
         "selftransfer": "Não podes transferir para ti próprio",
         "sale_timeout": "Espera um bocado antes de trocar o teu veículo",
-        "notallowed": "Não tens permissão para comprar este modelo"
+        "notallowed": "Não tens permissão para comprar este modelo",
+        "no_clear_spawn": "No spawn area found for vehicle."
     },
     "success": {
         "purchased": "Parabéns pela tua compra!",

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -23,7 +23,8 @@
         "buyerdeclined": "Jucătorul a refuzat tranzacția",
         "selftransfer": "Nu poți transfera către tine însuți",
         "sale_timeout": "Așteaptă un timp înainte de a tranzacționa vehiculul",
-        "notallowed": "Nu ai voie să achiziționezi acest model de vehicul"
+        "notallowed": "Nu ai voie să achiziționezi acest model de vehicul",
+        "no_clear_spawn": "No spawn area found for vehicle."
     },
     "success": {
         "purchased": "Felicitări pentru achiziția ta!",

--- a/server/finance.lua
+++ b/server/finance.lua
@@ -211,6 +211,11 @@ RegisterNetEvent('qbx_vehicleshop:server:sellfinanceVehicle', function(downPayme
         return exports.qbx_core:Notify(src, locale('error.notallowed'), 'error')
     end
 
+    local coords = GetClearSpawnArea(shop.vehicleSpawns)
+    if not coords then
+        return exports.qbx_core:Notify(src, locale('error.no_clear_spawn'), 'error')
+    end
+
     downPayment = tonumber(downPayment) --[[@as number]]
     paymentAmount = tonumber(paymentAmount) --[[@as number]]
 
@@ -250,7 +255,7 @@ RegisterNetEvent('qbx_vehicleshop:server:sellfinanceVehicle', function(downPayme
     })
 
     SpawnVehicle(src, {
-        coords = shop.vehicleSpawn,
+        coords = coords,
         vehicleId = vehicleId
     })
     financeTimer[target.PlayerData.source].hasFinanced = true
@@ -269,6 +274,11 @@ RegisterNetEvent('qbx_vehicleshop:server:financeVehicle', function(downPayment, 
 
     if not CheckVehicleList(vehicle, shopId) then
         return exports.qbx_core:Notify(src, locale('error.notallowed'), 'error')
+    end
+
+    local coords = GetClearSpawnArea(shop.vehicleSpawns)
+    if not coords then
+        return exports.qbx_core:Notify(src, locale('error.no_clear_spawn'), 'error')
     end
 
     local player = exports.qbx_core:GetPlayer(src)
@@ -315,7 +325,7 @@ RegisterNetEvent('qbx_vehicleshop:server:financeVehicle', function(downPayment, 
     exports.qbx_core:Notify(src, locale('success.purchased'), 'success')
 
     SpawnVehicle(src, {
-        coords = shop.vehicleSpawn,
+        coords = coords,
         vehicleId = vehicleId
     })
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -25,25 +25,31 @@ RegisterNetEvent('qbx_vehicleshop:server:testDrive', function(data)
     end
 
     local shopId = GetShopZone(src)
-    if not shopId then return end
+    local shop = sharedConfig.shops[shopId]
+    if not shop then return end
 
     if not CheckVehicleList(data.vehicle, shopId) then
         return exports.qbx_core:Notify(src, locale('error.notallowed'), 'error')
     end
 
-    local testDrive = sharedConfig.shops[shopId].testDrive
+    local coords = GetClearSpawnArea(shop.vehicleSpawns)
+    if not coords then
+        return exports.qbx_core:Notify(src, locale('error.no_clear_spawn'), 'error')
+    end
+
+    local testDrive = shop.testDrive
     local plate = 'TEST'..lib.string.random('1111')
 
     local netId = SpawnVehicle(src, {
         modelName = data.vehicle,
-        coords = testDrive.spawn,
+        coords = coords,
         plate = plate
     })
 
     testDrives[src] = {
         netId = netId,
         endBehavior = testDrive.endBehavior,
-        returnLocation = sharedConfig.shops[shopId].returnLocation
+        returnLocation = shop.returnLocation
     }
 
     Player(src).state:set('isInTestDrive', testDrive.limit, true)
@@ -122,6 +128,11 @@ RegisterNetEvent('qbx_vehicleshop:server:buyShowroomVehicle', function(vehicleDa
         return exports.qbx_core:Notify(src, locale('error.notallowed'), 'error')
     end
 
+    local coords = GetClearSpawnArea(shop.vehicleSpawns)
+    if not coords then
+        return exports.qbx_core:Notify(src, locale('error.no_clear_spawn'), 'error')
+    end
+
     local player = exports.qbx_core:GetPlayer(src)
     local vehiclePrice = COREVEHICLES[vehicle].price
     if not RemoveMoney(src, vehiclePrice, 'vehicle-bought-in-showroom') then
@@ -135,9 +146,8 @@ RegisterNetEvent('qbx_vehicleshop:server:buyShowroomVehicle', function(vehicleDa
 
     exports.qbx_core:Notify(src, locale('success.purchased'), 'success')
 
-
     SpawnVehicle(src, {
-        coords = shop.vehicleSpawn,
+        coords = coords,
         vehicleId = vehicleId
     })
 end)
@@ -187,6 +197,11 @@ RegisterNetEvent('qbx_vehicleshop:server:sellShowroomVehicle', function(vehicle,
         return exports.qbx_core:Notify(src, locale('error.notallowed'), 'error')
     end
 
+    local coords = GetClearSpawnArea(shop.vehicleSpawns)
+    if not coords then
+        return exports.qbx_core:Notify(src, locale('error.no_clear_spawn'), 'error')
+    end
+
     local vehiclePrice = COREVEHICLES[vehicle].price
     local cid = target.PlayerData.citizenid
 
@@ -198,7 +213,7 @@ RegisterNetEvent('qbx_vehicleshop:server:sellShowroomVehicle', function(vehicle,
     })
 
     SpawnVehicle(src, {
-        coords = shop.vehicleSpawn,
+        coords = coords,
         vehicleId = vehicleId
     })
 end)

--- a/server/utils.lua
+++ b/server/utils.lua
@@ -90,6 +90,18 @@ function RemoveMoney(src, amount, reason)
     return config.removePlayerFunds(player, currencyType, amount, reason)
 end
 
+---@param spawns vector4[]
+---@return vector4 | nil
+function GetClearSpawnArea(spawns)
+    for i = 1, #spawns do
+        local spawn = spawns[i]
+
+        if #lib.getNearbyVehicles(spawn.xyz) == 0 then
+            return spawn
+        end
+    end
+end
+
 ---@param src number
 ---@param data {coords: vector4, vehicleId?: number, modelName: string, plate?: string, props?: {plate: string}}
 ---@return number|nil

--- a/types.lua
+++ b/types.lua
@@ -53,7 +53,6 @@
 
 ---@class TestDriveConfig -- Test drive configuration
 ---@field limit number -- Time for test drive in minutes
----@field spawn vector4 -- Location to spawn test drive vehicle
 ---@field endBehavior 'return'|'destroy'|'none' -- 'none' will not do anything, 'return' will return the player to the dealership and destroy the vehicle, 'destroy' will destroy the vehicle and leave player at current position
 
 ---@class Dealership -- Dealership configuration
@@ -65,4 +64,4 @@
 ---@field showroomVehicles DealershipVehicle[]
 ---@field testDrive TestDriveConfig
 ---@field returnLocation vector3 -- Location to return the vehicle to for test drives
----@field vehicleSpawn vector4 -- Location to spawn purchased vehicles
+---@field vehicleSpawns vector4[] -- Locations to spawn purchased vehicles


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Adds multiple vehicle spawns and spawn checking.
If no spawn is clear, the player is not allowed to test/buy/finance the vehicle until a spawn area is clear.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
