### PR TITLE
Add client event handler for test drive requests

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -703,3 +703,10 @@ CreateThread(function()
         end
     end
 end)
+
+--- Handles test drive requests from cardealer employees
+---@param data {vehicle: string}
+RegisterNetEvent('qbx_vehicleshop:client:testDrive', function(data)
+    if not data or not data.vehicle then return end
+    TriggerServerEvent('qbx_vehicleshop:server:testDrive', data.vehicle)
+end)


### PR DESCRIPTION
Introduces a new event handler for 'qbx_vehicleshop:client:testDrive' that validates input and triggers the corresponding server event with the selected vehicle. This enables cardealer employees to initiate test drives.

## Description
This pull request introduces a new feature to handle test drive requests from cardealer employees in the `client/main.lua` file.

* **New Event Listener**: Added a `RegisterNetEvent` handler for the `qbx_vehicleshop:client:testDrive` event to process test drive requests. It validates the input data and triggers a corresponding server-side event (`qbx_vehicleshop:server:testDrive`) with the specified vehicle.
<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
